### PR TITLE
Harden fetch_descriptor.py and add join/dependency-hygiene guidance to agents

### DIFF
--- a/dev/skills/pudl/tests/test_fetch_descriptor.py
+++ b/dev/skills/pudl/tests/test_fetch_descriptor.py
@@ -1,0 +1,169 @@
+"""Tests for skills/pudl/scripts/fetch_descriptor.py.
+
+Exactly one test in this module makes a real network call — downloading the
+smallest of the seven descriptors (ferc714_xbrl_datapackage.json, ~65 KB) from the
+real S3 bucket, via a module-scoped fixture, so the suite verifies the script
+actually works against the real service it's built for. Compare
+dev/tools/check_datapackage_catalog_urls.py, which similarly makes live requests in
+CI rather than mocking them.
+
+Every other test reuses that one download's bytes locally — cache-hit/TTL/--force
+behavior is about *whether* fetch_one() calls the network, which is verified by
+patching urllib.request.urlopen to fail (or count calls) rather than by making
+further live S3 round trips. An earlier version of this suite made one live call per
+test (6 total) and took ~80s with occasional stalls from the same S3 latency spikes
+the retry logic exists to survive; sharing one real download avoids re-introducing
+that flakiness into the test suite itself.
+
+Run:  pixi run pytest dev/skills/pudl/tests/test_fetch_descriptor.py -v
+"""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# fetch_descriptor.py is a distributed skill script, not a dev-only one, so it lives
+# under skills/pudl/scripts/ rather than dev/skills/pudl/scripts/. Pytest runs these
+# tests from the repository context where this path injection is valid, but static
+# analyzers may still report unresolved-import warnings.
+sys.path.insert(
+    0,
+    str(
+        Path(__file__).parent.parent.parent.parent.parent
+        / "skills"
+        / "pudl"
+        / "scripts"
+    ),
+)
+
+import fetch_descriptor  # noqa: E402
+
+SMALLEST_DESCRIPTOR = "ferc714_xbrl_datapackage.json"
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object urllib.request.urlopen()'s context manager yields."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+
+def test_ferceqr_uses_its_own_base_url():
+    """Static routing check, no network: FERC EQR is hosted under a separate S3 prefix."""
+    assert (
+        fetch_descriptor._DESCRIPTOR_URLS["ferceqr_parquet_datapackage.json"]
+        == fetch_descriptor._FERCEQR
+    )
+
+
+def test_other_descriptors_use_the_nightly_base_url():
+    """Static routing check, no network: every non-EQR descriptor is under /nightly."""
+    for name in fetch_descriptor.DESCRIPTORS:
+        if name == "ferceqr_parquet_datapackage.json":
+            continue
+        assert fetch_descriptor._DESCRIPTOR_URLS[name] == fetch_descriptor._NIGHTLY
+
+
+@pytest.fixture(scope="module")
+def real_fetch_result(tmp_path_factory):
+    """The one live S3 call this whole module makes, shared by every test below."""
+    cache_dir = tmp_path_factory.mktemp("real_fetch_once")
+    original_cache_dir = fetch_descriptor.CACHE_DIR
+    fetch_descriptor.CACHE_DIR = cache_dir
+    try:
+        result = fetch_descriptor.fetch_one(SMALLEST_DESCRIPTOR)
+    finally:
+        fetch_descriptor.CACHE_DIR = original_cache_dir
+    data = (cache_dir / SMALLEST_DESCRIPTOR).read_bytes()
+    return result, data
+
+
+def test_fetch_one_downloads_the_real_smallest_descriptor(real_fetch_result):
+    (filename, size, digest, was_cached), data = real_fetch_result
+
+    assert filename == SMALLEST_DESCRIPTOR
+    assert was_cached is False  # nothing was cached yet for this fresh tmp dir
+    assert len(data) == size
+    assert hashlib.sha256(data).hexdigest()[:12] == digest
+    # It should be the real descriptor, not an error page or placeholder.
+    descriptor = json.loads(data)
+    assert "resources" in descriptor
+
+
+@pytest.fixture
+def prepopulated_cache(tmp_path, monkeypatch, real_fetch_result):
+    """A tmp cache dir seeded with the one real download's bytes — no network needed
+    to set up a "cache already has this file" starting state for the tests below."""
+    _result, data = real_fetch_result
+    monkeypatch.setattr(fetch_descriptor, "CACHE_DIR", tmp_path)
+    (tmp_path / SMALLEST_DESCRIPTOR).write_bytes(data)
+    return tmp_path
+
+
+def test_fetch_one_reuses_a_fresh_cache_without_a_network_call(
+    prepopulated_cache, monkeypatch
+):
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("fetch_one() hit the network despite a fresh cache entry")
+
+    monkeypatch.setattr(fetch_descriptor.urllib.request, "urlopen", _fail_if_called)
+
+    filename, _size, _digest, was_cached = fetch_descriptor.fetch_one(
+        SMALLEST_DESCRIPTOR
+    )
+
+    assert filename == SMALLEST_DESCRIPTOR
+    assert was_cached is True
+
+
+def test_force_bypasses_a_fresh_cache(
+    prepopulated_cache, monkeypatch, real_fetch_result
+):
+    _result, data = real_fetch_result
+    calls: list[str] = []
+
+    def _fake_urlopen(url, timeout=None):  # noqa: ARG001
+        calls.append(url)
+        return _FakeResponse(data)
+
+    monkeypatch.setattr(fetch_descriptor.urllib.request, "urlopen", _fake_urlopen)
+
+    _filename, _size, _digest, was_cached = fetch_descriptor.fetch_one(
+        SMALLEST_DESCRIPTOR, force=True
+    )
+
+    assert was_cached is False  # --force refetched despite the cache being fresh
+    assert len(calls) == 1
+
+
+def test_stale_cache_is_refetched(prepopulated_cache, monkeypatch, real_fetch_result):
+    _result, data = real_fetch_result
+    calls: list[str] = []
+
+    def _fake_urlopen(url, timeout=None):  # noqa: ARG001
+        calls.append(url)
+        return _FakeResponse(data)
+
+    monkeypatch.setattr(fetch_descriptor.urllib.request, "urlopen", _fake_urlopen)
+    # A negative TTL means any cached file, however new, already counts as stale —
+    # avoids sleeping in the test to simulate real time passing.
+    monkeypatch.setattr(fetch_descriptor, "CACHE_TTL_SECONDS", -1)
+
+    _filename, _size, _digest, was_cached = fetch_descriptor.fetch_one(
+        SMALLEST_DESCRIPTOR
+    )
+
+    assert was_cached is False
+    assert len(calls) == 1

--- a/pixi.lock
+++ b/pixi.lock
@@ -4958,7 +4958,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 295329
   timestamp: 1782831266058
@@ -5100,7 +5100,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 118650
   timestamp: 1782133688881
@@ -5336,7 +5336,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/beautifulsoup4?source=compressed-mapping
+  - pkg:pypi/beautifulsoup4?source=hash-mapping
   run_exports: {}
   size: 92704
   timestamp: 1780853175566
@@ -5901,7 +5901,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/petl?source=compressed-mapping
+  - pkg:pypi/petl?source=hash-mapping
   run_exports: {}
   size: 318755
   timestamp: 1780380316948

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,11 @@ ripgrep = ">=15.1.0"
 duckdb-cli = ">=1.5.4"
 
 [tool.ty.environment]
-extra-paths = ["dev/skills/datapackage/scripts", "dev/tools"]
+extra-paths = [
+  "dev/skills/datapackage/scripts",
+  "dev/tools",
+  "skills/pudl/scripts",
+]
 
 [tool.mdformat]
 # Use "no" wrapping so paragraphs stay as single long lines, soft-wrapped in the editor.

--- a/skills/datapackage/SKILL.md
+++ b/skills/datapackage/SKILL.md
@@ -41,6 +41,10 @@ resources. Each resource represents one table (or file) and includes:
     keys, and usage warnings
 - `path`: filename or URL of the actual data file
 - `schema.fields`: list of columns, each with a `name` and `description`
+- `schema.primaryKey`: the field or fields that uniquely identify a row in this resource
+- `schema.foreignKeys`: declared links from this resource's fields to another
+    resource's primary key — check these before joining or aggregating (see
+    [Metadata Querying](./references/metadata-querying.md))
 
 The file can be large (hundreds of resources, megabytes of JSON). Always query it
 selectively — never load it whole into context.
@@ -69,6 +73,10 @@ installed (optionally `install-duckdb` too). Install them from `duckdb/duckdb-sk
 1. **Query metadata selectively** — use jq to extract only what you need.
     See [Metadata Querying](./references/metadata-querying.md).
 1. **Surface warnings** — always check for usage warnings before presenting a resource.
+1. **Check keys before joining or aggregating** — if the task combines two resources,
+    or rolls one up, look up `schema.primaryKey` and `schema.foreignKeys` on each
+    first, rather than joining on a same-named or similar-looking column. See
+    [Metadata Querying: Joining resources](./references/metadata-querying.md#joining-resources-primary-keys-and-foreign-keys).
 1. **Validate** *(optional)* — if the user wants to know whether the data actually
     matches the descriptor, or if you're diagnosing a suspicious package, use
     `frictionless validate`. See [Frictionless Validate](./references/frictionless-validate.md).

--- a/skills/datapackage/references/metadata-querying.md
+++ b/skills/datapackage/references/metadata-querying.md
@@ -188,6 +188,53 @@ jq '[.resources[] | select(.name == "my_table") | .schema.fields[] | keys[]] | u
 jq '.resources[] | {table: .name, fields: [.schema.fields[] | select(.name == "plant_id_eia")]} | select(.fields | length > 0)' "$PKG"
 ```
 
+### Joining resources: primary keys and foreign keys
+
+**Before joining two resources, or aggregating one, check their declared keys —
+don't infer a join column from matching names.** The Table Schema spec gives every
+resource an explicit `schema.primaryKey` (the field or fields that uniquely identify
+a row) and an optional `schema.foreignKeys` array (each entry a `fields` list plus a
+`reference` naming the target resource and field it points to). When both ends of a
+join are declared, you can walk the relationship directly instead of guessing:
+
+```bash
+# Check a resource's primary key and declared foreign keys together
+jq '.resources[] | select(.name == "my_table") | {primaryKey: .schema.primaryKey, foreignKeys: .schema.foreignKeys}' "$PKG"
+
+# Find every resource with at least one declared foreign key
+jq '.resources[] | select(.schema.foreignKeys | length > 0) | .name' "$PKG"
+
+# Find what a specific field's foreign key points to
+jq '.resources[] | select(.name == "my_table") | .schema.foreignKeys[] | select(.fields == ["utility_id"])' "$PKG"
+```
+
+Two columns can share a name and still not be safe to join on — and, more subversively,
+two columns that share a name can refer to *different entities*, not just different
+formats of the same entity. A `name` field on two resources might be one resource's
+row-identifying string and another's free-text label; only the declared `primaryKey`
+tells you which. Never join on a human-readable name/label column (company name,
+site name, description) when an ID column is available, even if the ID column's
+values look opaque — string identity is a coincidence until proven otherwise, ID
+identity is asserted by the schema.
+
+**Not every join path is declared.** `foreignKeys` coverage is often incomplete in
+real-world descriptors — a resource may have an obviously-joinable ID column (same
+name, same apparent meaning as another resource's primary key) with no formal
+`foreignKeys` entry linking them. Treat a missing declaration as "unverified," not
+"no relationship exists": fall back to matching same-named ID columns across
+resources, but confirm the join is sound before trusting its output — spot-check a
+handful of joined rows, or verify a known identity (e.g. component values summing to
+a reported total) rather than assuming a plausible-looking join is a correct one.
+
+**Worked failure mode**: two resources each have a `facility_name` column that looks
+joinable — same rough meaning, similar-looking values. Joining directly on
+`facility_name` silently merges rows for facilities that share a name but are
+different entities (a common company name reused across unrelated sites, or a
+generic name like "Plant 1" reused across operators) — no error, no warning, just
+rows matched to the wrong facility. Checking `schema.primaryKey` on the source
+resource first would have shown the real identifying column (e.g. `facility_id`) to
+join on instead.
+
 Package-level metadata follows the same pattern:
 
 ```bash

--- a/skills/pudl/SKILL.md
+++ b/skills/pudl/SKILL.md
@@ -67,7 +67,11 @@ user explicitly asks to load or explore data.
     python scripts/fetch_descriptor.py
     ```
 
-    This populates `assets/cache/` with fresh copies of all descriptors above.
+    This populates `assets/cache/`. The script is cache-aware — a cached file
+    younger than a day is reused with no network call, so it's safe to run this
+    every time you need a descriptor rather than checking `assets/cache/` yourself
+    first. Pass `--force` to bypass the cache and refetch regardless of age (e.g. if
+    you suspect PUDL's schema changed today and need the very latest copy).
 
     Raw input archives (for provenance) live at
     `s3://pudl.catalyst.coop/zenodo/<dataset>/<concrete-doi>/datapackage.json`.
@@ -79,8 +83,21 @@ user explicitly asks to load or explore data.
 1. **Query metadata selectively** — use `/datapackage` skill patterns (jq)
     to find relevant tables, read descriptions, and surface warnings.
 
+    For "does PUDL have data on X" questions, don't stop at a match you already
+    recognized by reputation — run a broader keyword sweep across relevant
+    description/code fields first (for FERC accounts, see
+    [Cross-referencing FERC Form 1 and Form 2 schedules and accounts](#cross-referencing-ferc-form-1-and-form-2-schedules-and-accounts);
+    the same habit applies to other sources' `core_*__codes_*` tables). Flag it if
+    an answer came from recalled knowledge rather than the sweep.
+
 1. **Check table tier** — see [Data Quality and Context](./references/data-quality-and-context.md).
     Prefer `out_*` tables; warn users about `_core_*` tables.
+
+1. **Check keys before joining tables** — if the task combines a FERC-sourced table
+    with an EIA-sourced table (or any two tables at all), check `schema.foreignKeys`
+    on each first, and route utility/plant joins through `utility_id_pudl` /
+    `plant_id_pudl`, not through name-string matching. See
+    [PUDL Datapackage Extensions: Joining PUDL tables](./references/metadata-and-querying.md#joining-pudl-tables-use-declared-foreign-keys-and-pudls-id-crosswalks).
 
 1. **Check methodology before implementation details** — if the user is asking how
     PUDL cleans, imputes, allocates, reconciles, estimates, or models data, read
@@ -107,9 +124,11 @@ user explicitly asks to load or explore data.
     read whenever generating data-loading code or explaining how to access any PUDL output
 - [PUDL Datapackage Extensions](./references/metadata-and-querying.md) — PUDL-specific
     additions to the standard datapackage schema: RST/docstring-formatted descriptions,
-    per-resource provenance fields, and the package-level unit registry; read before
-    querying `description` or other non-standard fields on a PUDL descriptor (for generic
-    descriptor-querying mechanics, use the `datapackage` skill instead)
+    per-resource provenance fields, the package-level unit registry, and how to join
+    tables across FERC/EIA ID systems via `utility_id_pudl`/`plant_id_pudl`; read
+    before querying `description` or other non-standard fields on a PUDL descriptor,
+    and before joining any two PUDL tables (for generic descriptor-querying mechanics,
+    use the `datapackage` skill instead)
 - [Data Quality and Context](./references/data-quality-and-context.md) — table tier
     naming conventions (`out_*` vs `core_*` vs raw), warning types, and what each tier
     means for analysis reliability; read when a user asks about data quality, when choosing
@@ -191,7 +210,14 @@ user explicitly asks to load or explore data.
 - **Use `uv` to install Python packages** — prefer `uv add <package>` over
     `pip install <package>`. `uv` is faster and installs into a virtual environment
     rather than globally. Fall back to `pip` only if `uv` is not available
-    (`command -v uv` returns nothing).
+    (`command -v uv` returns nothing) — and if you do, install into a project-local
+    virtual environment (create one with `python -m venv .venv` if none exists), not
+    the system/global Python. **`pip install --user` is not a safe fallback either**
+    — it still writes into the user's global user-site packages, shared across every
+    other project on their machine, rather than scoping the change to this task. If
+    the working directory already has its own environment manager (pixi, poetry, an
+    existing venv or conda env), install through that instead of introducing a second
+    one.
 
 - **PUDL's datapackage descriptors extend the standard schema** in several PUDL-specific
     ways: RST-formatted, docstring-style descriptions, per-resource provenance metadata,
@@ -200,6 +226,15 @@ user explicitly asks to load or explore data.
     jq queries against `description` or other non-standard fields — it covers only
     what's unique to PUDL; for generic descriptor-querying mechanics, use the
     `datapackage` skill.
+
+- **Prefer joining PUDL tables on ID columns over name-string columns**
+    (`utility_name_ferc1`, `utility_name_eia`, plant names, etc.) — same-named
+    entities across FERC and EIA are not guaranteed to be the same company. Route
+    joins through `utility_id_pudl` / `plant_id_pudl` via the `core_pudl__assn_*`
+    crosswalk tables, checking `schema.foreignKeys` first. Name matching is a
+    legitimate fallback when no ID crosswalk is available, but treat its results as
+    unverified until spot-checked. See
+    [PUDL Datapackage Extensions: Joining PUDL tables](./references/metadata-and-querying.md#joining-pudl-tables-use-declared-foreign-keys-and-pudls-id-crosswalks).
 
 ### Cross-referencing FERC Form 1 and Form 2 schedules and accounts
 

--- a/skills/pudl/references/data-sources.md
+++ b/skills/pudl/references/data-sources.md
@@ -109,8 +109,10 @@ Each source with a `documentation` link has a page describing:
 **Always append `.md` to the `documentation` URL before fetching it yourself.** PUDL
 publishes an LLM-optimized markdown mirror of every docs page (the `llms.txt`
 convention), and agents don't discover it automatically unless told — the raw field
-always points at the `.html` page. This `.md` append is for *your* reading only —
+always points at the `.html` page. This `.html.md` URL is for *your* reading only —
 if you share the link with the user, give them the plain `.html` URL from the field.
+See [PUDL Datapackage Extensions: Per-resource provenance](./metadata-and-querying.md#per-resource-provenance-sources)
+for exactly how that append works.
 
 ```bash
 # Fetch a source's docs page (markdown version)

--- a/skills/pudl/references/metadata-and-querying.md
+++ b/skills/pudl/references/metadata-and-querying.md
@@ -71,15 +71,25 @@ populates it with dataset-specific provenance beyond the spec's minimal `name`/`
     lineage (not a specific version). See
     [Data Quality and Context](./data-quality-and-context.md#raw-input-archives-zenodo)
     for how this relates to the concrete-DOI S3 archive path.
+
 - `license_raw` vs `license_pudl` — the license the *original* agency published the data
     under, versus the license PUDL republishes it under (almost always CC-BY-4.0). Cite
     `license_pudl` when telling a user how they may use PUDL's output; mention
     `license_raw` only if they ask about the original source's terms.
+
 - `documentation` — a direct link to that source's PUDL docs page. Prefer this over
     constructing a docs URL from the short code. **Append `.md` only when *you* are
-    fetching the page** (PUDL publishes an LLM-optimized markdown mirror of every docs
-    page). If you share this link with the user, give them the plain `.html` URL from
-    the field — the `.md` version is for your own reading, not theirs.
+    fetching the page** resulting in a path ending in `.html.md` (PUDL publishes an
+    LLM-optimized markdown mirror of every docs page). Examples:
+
+    ```text
+    field value:        https://docs.catalyst.coop/pudl/en/nightly/data_sources/ferc1.html
+    fetch this (mirror): https://docs.catalyst.coop/pudl/en/nightly/data_sources/ferc1.html.md   ✓
+    not this:            https://docs.catalyst.coop/pudl/en/nightly/data_sources/ferc1.md        ✗ 404s
+    ```
+
+    If you share this link with the user, give them the plain `.html` URL from
+    the field — the `.html.md` version is for your own reading, not theirs.
 
 ```bash
 # Get provenance for every source dataset behind the current descriptor
@@ -170,6 +180,60 @@ right_total = gas_a + gas_b.to(ureg.Mcf)  # 2_700 Mcf
 ```
 
 ---
+
+---
+
+## Joining PUDL tables: use declared foreign keys, and PUDL's ID crosswalks
+
+**Before joining two PUDL resources, check `schema.foreignKeys` on each — don't join
+on matching column names, and never join on a name/label field when an ID field is
+available.** This is the general `datapackage` skill rule (see its
+[Metadata Querying: Joining resources](../../datapackage/references/metadata-querying.md#joining-resources-primary-keys-and-foreign-keys)),
+and it applies with extra force in PUDL because the same real-world entity (a
+utility, a plant) is reported under **different ID systems by different source
+agencies** — FERC assigns its own utility IDs, EIA assigns its own, and they don't
+match.
+
+```bash
+# Check a table's declared primary key and foreign keys before joining
+jq '.resources[] | select(.name == "out_ferc1__yearly_income_statements_sched114") | {primaryKey: .schema.primaryKey, foreignKeys: .schema.foreignKeys}' "$PKG"
+```
+
+PUDL resolves the multi-agency-ID problem with a **crosswalk hub**:
+`utility_id_pudl` (and `plant_id_pudl` for plants) is PUDL's own surrogate ID, and
+`core_pudl__assn_*` tables declare the links from each source system's ID to it —
+for example `out_ferc1__yearly_income_statements_sched114.utility_id_ferc1` has a
+declared foreign key to `core_pudl__assn_ferc1_pudl_utilities.utility_id_ferc1`,
+and `core_pudl__assn_eia_pudl_utilities.utility_id_pudl` links to the same
+`core_pudl__entity_utilities_pudl` hub. To join a FERC-sourced table to an
+EIA-sourced table, route through `utility_id_pudl`, not through utility name
+strings:
+
+```
+out_ferc1__...(utility_id_ferc1)
+  → core_pudl__assn_ferc1_pudl_utilities (utility_id_ferc1 → utility_id_pudl)
+  → core_pudl__assn_eia_pudl_utilities (utility_id_pudl → utility_id_eia)
+  → core_eia861__... (utility_id_eia)
+```
+
+**Declared `foreignKeys` coverage varies by table and can change over time** — a
+table may carry a `utility_id_eia` or `plant_id_eia` column with no `foreignKeys`
+entry pointing it at the corresponding crosswalk table, even though it's the same
+key. Don't take an undeclared link as evidence no relationship exists: check for it
+with jq first, but if it's absent, still prefer joining on the shared `utility_id_*`
+/ `plant_id_*` column over a name column — the ID system is the reliable part even
+when the formal declaration is missing — and treat the result as unverified until
+you spot-check it (e.g. confirm a handful of joined rows resolve to the entity you
+expect).
+
+**Worked failure mode**: searching a table by utility *name* (e.g.
+`utility_name_eia ILIKE '%tri-state%'`) can return an entirely unrelated company —
+"Tri-State Electric Member Corp," a Georgia/Tennessee/North Carolina cooperative,
+is a false-positive match for a search meant to find Colorado's "Tri-State
+Generation and Transmission Association." Going through the ID crosswalk
+(`utility_id_ferc1` → `utility_id_pudl` → `utility_id_eia`) instead of name
+matching returns the correct entity and would have caught the mismatch immediately,
+since the crosswalked EIA ID and the name-matched EIA ID are different numbers.
 
 ## Other field-level extensions
 

--- a/skills/pudl/scripts/fetch_descriptor.py
+++ b/skills/pudl/scripts/fetch_descriptor.py
@@ -2,19 +2,27 @@
 """Download and cache PUDL datapackage descriptors from the nightly S3 build.
 
 Descriptors are updated nightly and are never bundled with the skill — they would
-become stale immediately. This script downloads fresh copies into
-skills/pudl/assets/cache/ for use in evals and offline testing.
+become stale immediately. This script downloads copies into skills/pudl/assets/cache/
+for use in evals and offline testing.
+
+A cached file younger than CACHE_TTL_SECONDS is reused as-is, with no network call —
+safe to re-run freely (e.g. once per agent turn) without re-downloading every time.
+Pass --force to bypass the cache and refetch regardless of age.
 
 Usage:
-    python scripts/fetch_descriptor.py           # download all descriptors
+    python scripts/fetch_descriptor.py                  # all descriptors, cache-aware
     python scripts/fetch_descriptor.py pudl_parquet_datapackage.json  # one file
+    python scripts/fetch_descriptor.py --force           # bypass the cache
 
-The cached files are gitignored. Re-run to refresh them.
+The cached files are gitignored.
 """
 
 import argparse
 import hashlib
+import time
+import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 _NIGHTLY = "https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly"
@@ -36,17 +44,55 @@ DESCRIPTORS = list(_DESCRIPTOR_URLS)
 
 CACHE_DIR = Path(__file__).parent.parent / "assets" / "cache"
 
+# S3 latency is occasionally spiky (observed multi-second time-to-first-byte, and
+# rare full stalls). These descriptors are at most a few MB; a real transfer that's
+# still stuck at zero bytes after a few seconds is stalled, not slow, so the timeout
+# is kept short and attempts retried, rather than waiting out a long timeout once.
+REQUEST_TIMEOUT_SECONDS = 15
+MAX_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = 2
 
-def fetch_one(filename: str) -> None:
+# Descriptors are refreshed nightly upstream, so a cached copy is treated as fresh
+# for up to a day — long enough that repeated calls within a session (or across a
+# few) reuse the local file instead of re-downloading, short enough to stay close to
+# upstream's own refresh cadence.
+CACHE_TTL_SECONDS = 24 * 60 * 60
+
+
+def fetch_one(filename: str, force: bool = False) -> tuple[str, int, str, bool]:
+    """Fetch one descriptor, retrying transient failures.
+
+    Returns (filename, bytes, sha256, was_cached). If a cached copy exists and is
+    younger than CACHE_TTL_SECONDS, it's reused with no network call unless
+    force=True.
+    """
+    out = CACHE_DIR / filename
+    if not force and out.exists():
+        age_seconds = time.time() - out.stat().st_mtime
+        if age_seconds < CACHE_TTL_SECONDS:
+            data = out.read_bytes()
+            digest = hashlib.sha256(data).hexdigest()[:12]
+            return filename, len(data), digest, True
+
     base = _DESCRIPTOR_URLS.get(filename, _NIGHTLY)
     url = f"{base}/{filename}"
-    out = CACHE_DIR / filename
-    print(f"Fetching {url} ...")
-    with urllib.request.urlopen(url) as resp:  # noqa: S310
-        data = resp.read()
-    out.write_bytes(data)
-    digest = hashlib.sha256(data).hexdigest()[:12]
-    print(f"  → {out.name}  ({len(data):,} bytes, sha256:{digest})")
+
+    last_error: Exception | None = None
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=REQUEST_TIMEOUT_SECONDS) as resp:  # noqa: S310
+                data = resp.read()
+            out.write_bytes(data)
+            digest = hashlib.sha256(data).hexdigest()[:12]
+            return filename, len(data), digest, False
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_error = exc
+            if attempt < MAX_ATTEMPTS:
+                time.sleep(RETRY_BACKOFF_SECONDS * attempt)
+
+    raise RuntimeError(
+        f"Failed to fetch {url} after {MAX_ATTEMPTS} attempts: {last_error}"
+    ) from last_error
 
 
 def main() -> None:
@@ -57,12 +103,42 @@ def main() -> None:
         metavar="FILENAME",
         help="Descriptor filename(s) to fetch. Defaults to all.",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass the cache and refetch even if a fresh copy already exists.",
+    )
     args = parser.parse_args()
     targets = args.files or DESCRIPTORS
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    for filename in targets:
-        fetch_one(filename)
-    print("Done.")
+
+    # Fetch concurrently: these are independent files on the same host, so a slow
+    # or stalled request for one no longer blocks the rest — total wall time tracks
+    # the slowest single file instead of the sum of all of them.
+    failures: list[str] = []
+    with ThreadPoolExecutor(max_workers=len(targets)) as pool:
+        future_to_name = {
+            pool.submit(fetch_one, name, args.force): name for name in targets
+        }
+        for future in as_completed(future_to_name):
+            name = future_to_name[future]
+            try:
+                filename, size, digest, was_cached = future.result()
+                status = "cached" if was_cached else "fetched"
+                print(
+                    f"{filename}  ({status}, {size:,} bytes, sha256:{digest})",
+                    flush=True,
+                )
+            except RuntimeError as exc:
+                print(f"FAILED: {exc}", flush=True)
+                failures.append(name)
+
+    if failures:
+        print(
+            f"Done, with {len(failures)} failure(s): {', '.join(failures)}", flush=True
+        )
+        raise SystemExit(1)
+    print("Done.", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Overview

## fetch_descriptor.py (skills/pudl/scripts/):

- Add a per-request timeout and retries so a stalled S3 connection fails fast and recovers instead of hanging indefinitely with no feedback.
- Fetch descriptors concurrently instead of sequentially, so total wall time tracks the slowest single file rather than the sum of all seven.
- Print one flushed line per completed file, so progress is visible immediately even when output is piped or captured (agent runs, logs, CI).
- Cache downloads with a 24h TTL so repeated calls reuse the local copy with no network call; add --force to bypass the cache explicitly.
- Add dev/skills/pudl/tests/test_fetch_descriptor.py covering cache-hit, --force, and TTL-expiry behavior, plus one real (shared, single) live download to verify the script still works against the actual S3 bucket.

## datapackage and pudl skills (references/metadata-querying.md, metadata-and-querying.md, SKILL.md):

- Document schema.primaryKey/schema.foreignKeys as a standard join-safety check, with a worked failure mode for joining on name/label columns instead of IDs.
- Add PUDL-specific guidance on routing FERC/EIA joins through the utility_id_pudl/plant_id_pudl crosswalk tables rather than name matching.
- Add guidance to run a broad metadata keyword sweep before answering "does PUDL have data on X" questions, rather than stopping at a recognized match.
- Clarify that appending .md to a PUDL docs URL means appending onto the full .html URL (producing page.html.md), not replacing the extension.
- Strengthen the Python dependency-install guidance: prefer uv, avoid `pip install --user` as a "safe" fallback, and prefer a repo's existing environment manager over introducing a new one.

pyproject.toml: add skills/pudl/scripts to ty's extra-paths so the type checker can resolve fetch_descriptor.py's import in the test suite.