### PR TITLE
PUDL Skill tweaks

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -16,8 +16,8 @@ jobs:
     name: Auto-merge passing bot PRs
     runs-on: ubuntu-latest
     if: >-
-      github.actor == 'dependabot[bot]' ||
-      github.actor == 'pre-commit-ci[bot]'
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'pre-commit-ci[bot]'
     steps:
       - name: Impersonate auto merge PR bot
         uses: actions/create-github-app-token@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,15 +43,6 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: local
-    hooks:
-      - id: pyrefly-check
-        name: pyrefly-check
-        entry: pixi run pyrefly check
-        language: system
-        types_or: [python, pyi]
-        pass_filenames: false
-
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.9.6
     hooks:
@@ -86,6 +77,25 @@ repos:
 
   - repo: local
     hooks:
+      - id: pyrefly-check
+        name: pyrefly-check
+        entry: pixi run pyrefly check
+        language: system
+        types_or: [python, pyi]
+        pass_filenames: false
+      - id: update-skill-last-updated
+        name: update `last-updated` metadata in SKILL.md
+        language: system
+        files: ^skills/.*/SKILL\.md$
+        pass_filenames: true
+        entry: |-
+          bash -c '
+          today=$(date +%Y-%m-%d)
+          for f in "$@"; do
+            sed -i.bak -E "s/^([[:space:]]*-[[:space:]]*last-updated:).*/\1 ${today}/" "$f"
+            rm -f "$f.bak"
+          done
+          ' --
       - id: pytest
         name: pytest
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  skip: [pyrefly-check]
+  skip: [pyrefly-check, pytest]
 
 repos:
   - repo: https://github.com/DavidAnson/markdownlint-cli2
@@ -83,3 +83,14 @@ repos:
     rev: v1.48.0
     hooks:
       - id: typos
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        stages: [pre-commit]
+        language: unsupported
+        verbose: false
+        pass_filenames: false
+        always_run: true
+        entry: pixi run test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  skip: [pyrefly-check, pytest]
+  skip: [pyrefly-check, pytest, last-updated]
 
 repos:
   - repo: https://github.com/DavidAnson/markdownlint-cli2
@@ -83,7 +83,7 @@ repos:
         language: system
         types_or: [python, pyi]
         pass_filenames: false
-      - id: update-skill-last-updated
+      - id: last-updated
         name: update `last-updated` metadata in SKILL.md
         language: system
         files: ^skills/.*/SKILL\.md$

--- a/dev/skills/pudl/pudl-dev-guide.md
+++ b/dev/skills/pudl/pudl-dev-guide.md
@@ -43,6 +43,19 @@ If a new documented example needs a resource, source, or field the sample
 doesn't currently carry, add it to the `SOURCE_NAMES` list or `RESOURCE_FIELDS`
 mapping in `build_metadata_fixture.py` — don't hand-edit the generated JSON.
 
+## markitdown is deliberately not a pixi dependency
+
+`test_markitdown_conversion.py` builds its own throwaway `uv`-managed venv rather than
+using a pixi-installed `markitdown`. This isn't a stopgap — adding `markitdown[pdf]`
+directly to this workspace's pixi environment currently fails to solve at all on
+`osx-arm64` with Python ≥ 3.14: its transitive dependency chain
+(`magika` → `onnxruntime`) has no wheel matching pixi's default macOS platform-tag
+baseline for `cp314`, even though a plain `uv pip install "markitdown[pdf]"` on the
+same machine resolves and runs it fine (`uv` resolves against the running machine;
+pixi resolves against a portable baseline). If you try `pixi add markitdown` again
+after an upstream release and it still fails, that's this same gap, not a fluke —
+keep using the `uv`-venv pattern rather than fighting the pixi solver.
+
 ## Guardrails
 
 - Keep distributed skill docs free of references to dev-only paths and scripts.

--- a/dev/skills/pudl/tests/test_data_access.py
+++ b/dev/skills/pudl/tests/test_data_access.py
@@ -1,0 +1,126 @@
+"""Tests for the pandas/DuckDB/polars S3 query patterns documented in
+references/data-access.md.
+
+All tests make a real network call against the live PUDL S3 bucket, following the
+same live-call precedent as test_fetch_descriptor.py: this suite exists specifically
+to catch regressions in *reachability* (SSL/addressing quirks, stale table names,
+credential handling), which a mocked or local fixture can't surface. Each test
+targets the smallest resource that still exercises the documented pattern, to keep
+the live calls cheap.
+
+pudl.catalyst.coop is free and public and needs no AWS credentials. But whether a
+developer's machine happens to have credentials configured (valid, invalid, or none)
+must not change whether these tests pass -- that would make the suite's result an
+accident of the local environment rather than a check of whether the documented
+patterns actually work for a user with nothing configured. The autouse fixture below
+strips every source of ambient AWS credentials so the tests are hermetic; each
+library's read then relies solely on the documented anonymous-access options
+(`s3_access_key_id`/`s3_secret_access_key` for DuckDB, `anon` for pandas,
+`aws_skip_signature` for polars) to prove those options are sufficient on their own.
+
+Run:  pixi run pytest dev/skills/pudl/tests/test_data_access.py -v
+"""
+
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import polars as pl
+import pytest
+
+# Smallest core_*__codes_* parquet file in the nightly build (a few KB) --
+# exercises the documented "read_parquet over s3://" pattern cheaply.
+SMALL_PARQUET_TABLE = "core_rus__codes_fuel_types"
+SMALL_PARQUET_URL = f"s3://pudl.catalyst.coop/nightly/{SMALL_PARQUET_TABLE}.parquet"
+
+# Smallest of the five FERC XBRL DuckDB databases (~50 MB) -- exercises the
+# documented "ATTACH a remote .duckdb file" pattern. ATTACH is queried over
+# https://, not s3://, per the note in data-access.md.
+FERC60_XBRL_HTTPS_URL = (
+    "https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/ferc60_xbrl.duckdb"
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_aws_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Strip every source of ambient AWS credentials for every test in this module.
+
+    boto3 (pandas/s3fs) and the object_store crate (polars) both consult
+    AWS_* environment variables and the default credentials/config files before
+    falling back to instance-metadata lookups. Clearing all of them means a test
+    only passes because the documented anonymous-access option actually works --
+    not because the machine running the suite happens to have (valid or invalid)
+    credentials lying around.
+    """
+    for var in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+        "AWS_DEFAULT_REGION",
+        "AWS_REGION",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv(
+        "AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "no-such-credentials-file")
+    )
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-such-config-file"))
+
+
+def test_read_parquet_from_s3_with_path_style_addressing() -> None:
+    """The documented fix (SET s3_url_style = 'path') makes read_parquet() over
+    s3:// work against the pudl.catalyst.coop bucket, whose dotted name otherwise
+    breaks DuckDB's default virtual-hosted-style S3 addressing. Clearing the S3
+    credential settings forces the anonymous request this public bucket needs,
+    rather than relying on no credentials being configured."""
+    con = duckdb.connect()
+    con.execute("SET s3_url_style = 'path'")
+    con.execute("SET s3_access_key_id = ''")
+    con.execute("SET s3_secret_access_key = ''")
+    df = con.execute(f"SELECT * FROM read_parquet('{SMALL_PARQUET_URL}') LIMIT 5").df()
+    assert not df.empty
+    assert "code" in df.columns
+    assert "description" in df.columns
+
+
+def test_pandas_read_parquet_from_s3() -> None:
+    """pandas (via s3fs) needs storage_options={"anon": True} to guarantee anonymous
+    access -- without it, s3fs tries to sign requests with whatever credentials (even
+    invalid ones) it finds first, which fails against a public bucket that never
+    expected them."""
+    df = pd.read_parquet(SMALL_PARQUET_URL, storage_options={"anon": True})
+    assert not df.empty
+    assert "code" in df.columns
+    assert "description" in df.columns
+
+
+def test_polars_scan_parquet_from_s3() -> None:
+    """polars needs storage_options={"aws_skip_signature": "true", "aws_region": ...}
+    -- unlike pandas/s3fs, it doesn't fall back to anonymous access on its own, so
+    without this it either hangs on an EC2 instance-metadata lookup or fails because
+    it can't determine the bucket's region."""
+    df = (
+        pl.scan_parquet(
+            SMALL_PARQUET_URL,
+            storage_options={"aws_skip_signature": "true", "aws_region": "us-west-2"},
+        )
+        .select(["code", "description"])
+        .collect()
+    )
+    assert not df.is_empty()
+    assert df.columns == ["code", "description"]
+
+
+def test_attach_ferc_xbrl_duckdb_over_https() -> None:
+    """DuckDB's ATTACH rejects s3:// URIs outright (regardless of s3_url_style),
+    so the documented pattern uses the https:// form instead. That form doesn't go
+    through DuckDB's S3 credential-signing path at all, so no anonymous-access
+    setting is needed here."""
+    con = duckdb.connect()
+    con.execute(f"ATTACH '{FERC60_XBRL_HTTPS_URL}' AS ferc60 (READ_ONLY)")
+    tables = con.execute(
+        "SELECT table_name FROM duckdb_tables() WHERE database_name = 'ferc60' LIMIT 1"
+    ).fetchall()
+    assert tables, "Expected at least one table in the attached ferc60 XBRL database"

--- a/dev/skills/pudl/tests/test_data_access.py
+++ b/dev/skills/pudl/tests/test_data_access.py
@@ -21,6 +21,7 @@ library's read then relies solely on the documented anonymous-access options
 Run:  pixi run pytest dev/skills/pudl/tests/test_data_access.py -v
 """
 
+import datetime
 from pathlib import Path
 
 import duckdb
@@ -32,6 +33,12 @@ import pytest
 # exercises the documented "read_parquet over s3://" pattern cheaply.
 SMALL_PARQUET_TABLE = "core_rus__codes_fuel_types"
 SMALL_PARQUET_URL = f"s3://pudl.catalyst.coop/nightly/{SMALL_PARQUET_TABLE}.parquet"
+
+# Used for the column+row pushdown tests below -- large enough that pulling it in
+# full would be wasteful, which is exactly the point of those tests: a pushed-down
+# filter should only read the matching row groups, not the whole file.
+GENERATION_TABLE_URL = "s3://pudl.catalyst.coop/nightly/out_eia923__generation.parquet"
+FILTER_CUTOFF_DATE = datetime.date(2020, 1, 1)
 
 # Smallest of the five FERC XBRL DuckDB databases (~50 MB) -- exercises the
 # documented "ATTACH a remote .duckdb file" pattern. ATTACH is queried over
@@ -96,6 +103,23 @@ def test_pandas_read_parquet_from_s3() -> None:
     assert "description" in df.columns
 
 
+def test_pandas_read_parquet_with_column_and_row_filters() -> None:
+    """pandas' `filters=` pushes a row filter down to the Parquet reader alongside
+    `columns=`, so only matching row groups are ever read. `filters=` must compare
+    against the column's actual type -- a `datetime.date`, not a string, for a date
+    column -- or pyarrow raises ArrowNotImplementedError."""
+    df = pd.read_parquet(
+        GENERATION_TABLE_URL,
+        columns=["plant_id_eia", "report_date"],
+        filters=[("report_date", ">=", FILTER_CUTOFF_DATE)],
+        storage_options={"anon": True},
+    )
+    assert not df.empty
+    assert list(df.columns) == ["plant_id_eia", "report_date"]
+    # report_date round-trips as plain datetime.date (object dtype), not Timestamp.
+    assert (df["report_date"] >= FILTER_CUTOFF_DATE).all()
+
+
 def test_polars_scan_parquet_from_s3() -> None:
     """polars needs storage_options={"aws_skip_signature": "true", "aws_region": ...}
     -- unlike pandas/s3fs, it doesn't fall back to anonymous access on its own, so
@@ -111,6 +135,24 @@ def test_polars_scan_parquet_from_s3() -> None:
     )
     assert not df.is_empty()
     assert df.columns == ["code", "description"]
+
+
+def test_polars_scan_parquet_with_select_and_filter() -> None:
+    """Chaining .select()/.filter() before .collect() on a lazy scan pushes both
+    the column and row selection down to the Parquet reader, same as pandas'
+    columns=/filters=, rather than materializing the full table first."""
+    df = (
+        pl.scan_parquet(
+            GENERATION_TABLE_URL,
+            storage_options={"aws_skip_signature": "true", "aws_region": "us-west-2"},
+        )
+        .select(["plant_id_eia", "report_date"])
+        .filter(pl.col("report_date") >= pl.lit(FILTER_CUTOFF_DATE))
+        .collect()
+    )
+    assert not df.is_empty()
+    assert df.columns == ["plant_id_eia", "report_date"]
+    assert (df["report_date"] >= FILTER_CUTOFF_DATE).all()
 
 
 def test_attach_ferc_xbrl_duckdb_over_https() -> None:

--- a/dev/skills/pudl/tests/test_data_access.py
+++ b/dev/skills/pudl/tests/test_data_access.py
@@ -40,11 +40,11 @@ SMALL_PARQUET_URL = f"s3://pudl.catalyst.coop/nightly/{SMALL_PARQUET_TABLE}.parq
 GENERATION_TABLE_URL = "s3://pudl.catalyst.coop/nightly/out_eia923__generation.parquet"
 FILTER_CUTOFF_DATE = datetime.date(2020, 1, 1)
 
-# Smallest of the five FERC XBRL DuckDB databases (~50 MB) -- exercises the
-# documented "ATTACH a remote .duckdb file" pattern. ATTACH is queried over
-# https://, not s3://, per the note in data-access.md.
-FERC60_XBRL_HTTPS_URL = (
-    "https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/ferc60_xbrl.duckdb"
+# A table from the raw per-form FERC Parquet directories -- exercises the documented
+# "raw per-form Parquet directory" pattern (one Parquet file per table, alongside a
+# datapackage.json, under nightly/<form>_<era>/).
+FERC1_XBRL_TABLE_URL = (
+    "s3://pudl.catalyst.coop/nightly/ferc1_xbrl/identification_001_duration.parquet"
 )
 
 
@@ -155,14 +155,15 @@ def test_polars_scan_parquet_with_select_and_filter() -> None:
     assert (df["report_date"] >= FILTER_CUTOFF_DATE).all()
 
 
-def test_attach_ferc_xbrl_duckdb_over_https() -> None:
-    """DuckDB's ATTACH rejects s3:// URIs outright (regardless of s3_url_style),
-    so the documented pattern uses the https:// form instead. That form doesn't go
-    through DuckDB's S3 credential-signing path at all, so no anonymous-access
-    setting is needed here."""
+def test_read_raw_ferc_xbrl_parquet_table_from_s3() -> None:
+    """Raw per-form FERC data (DBF- and XBRL-derived) is published as one Parquet
+    file per table inside a per-form/era directory, read the same way as any other
+    PUDL Parquet table -- no SQLite/DuckDB database or download required."""
     con = duckdb.connect()
-    con.execute(f"ATTACH '{FERC60_XBRL_HTTPS_URL}' AS ferc60 (READ_ONLY)")
-    tables = con.execute(
-        "SELECT table_name FROM duckdb_tables() WHERE database_name = 'ferc60' LIMIT 1"
-    ).fetchall()
-    assert tables, "Expected at least one table in the attached ferc60 XBRL database"
+    con.execute("SET s3_url_style = 'path'")
+    con.execute("SET s3_access_key_id = ''")
+    con.execute("SET s3_secret_access_key = ''")
+    df = con.execute(
+        f"SELECT * FROM read_parquet('{FERC1_XBRL_TABLE_URL}') LIMIT 5"
+    ).df()
+    assert not df.empty

--- a/dev/skills/pudl/tests/test_fetch_descriptor.py
+++ b/dev/skills/pudl/tests/test_fetch_descriptor.py
@@ -1,7 +1,7 @@
 """Tests for skills/pudl/scripts/fetch_descriptor.py.
 
 Exactly one test in this module makes a real network call — downloading the
-smallest of the seven descriptors (ferc714_xbrl_datapackage.json, ~65 KB) from the
+smallest of the eleven descriptors (ferc714_xbrl_datapackage.json, ~65 KB) from the
 real S3 bucket, via a module-scoped fixture, so the suite verifies the script
 actually works against the real service it's built for. Compare
 dev/tools/check_datapackage_catalog_urls.py, which similarly makes live requests in
@@ -64,10 +64,9 @@ class _FakeResponse:
 
 def test_ferceqr_uses_its_own_base_url() -> None:
     """Static routing check, no network: FERC EQR is hosted under a separate S3 prefix."""
-    assert (
-        fetch_descriptor._DESCRIPTOR_URLS["ferceqr_parquet_datapackage.json"]
-        == fetch_descriptor._FERCEQR
-    )
+    assert fetch_descriptor._DESCRIPTOR_URLS[
+        "ferceqr_parquet_datapackage.json"
+    ].startswith(fetch_descriptor._FERCEQR)
 
 
 def test_other_descriptors_use_the_nightly_base_url() -> None:
@@ -75,7 +74,18 @@ def test_other_descriptors_use_the_nightly_base_url() -> None:
     for name in fetch_descriptor.DESCRIPTORS:
         if name == "ferceqr_parquet_datapackage.json":
             continue
-        assert fetch_descriptor._DESCRIPTOR_URLS[name] == fetch_descriptor._NIGHTLY
+        assert fetch_descriptor._DESCRIPTOR_URLS[name].startswith(
+            fetch_descriptor._NIGHTLY
+        )
+
+
+def test_raw_ferc_form_descriptors_point_at_their_own_subdirectory() -> None:
+    """Static routing check, no network: each raw per-form FERC descriptor (e.g.
+    ferc1_xbrl_datapackage.json) is cached under a disambiguated local filename but
+    fetched from the shared remote name `datapackage.json` inside that form/era's own
+    S3 subdirectory, since every such subdirectory publishes a same-named descriptor."""
+    url = fetch_descriptor._DESCRIPTOR_URLS["ferc1_xbrl_datapackage.json"]
+    assert url == f"{fetch_descriptor._NIGHTLY}/ferc1_xbrl/datapackage.json"
 
 
 @pytest.fixture(scope="module")

--- a/dev/skills/pudl/tests/test_markitdown_conversion.py
+++ b/dev/skills/pudl/tests/test_markitdown_conversion.py
@@ -1,0 +1,158 @@
+"""Tests for the markitdown-based file-to-text conversion pattern documented in
+references/data-sources.md, under "Blank forms and filer instructions" -> "Reading
+them".
+
+markitdown can't currently join this repository's shared pixi dev environment: its
+transitive dependency chain (magika -> onnxruntime) has no wheel compatible with
+pixi's default osx-arm64 platform-tag baseline for Python 3.14, even though a plain
+`uv pip install "markitdown[pdf]"` on this same machine resolves and runs it fine.
+That gap is exactly why the skill documents installing markitdown on demand in a
+throwaway environment rather than assuming it's preinstalled -- so these tests build
+that same throwaway environment with `uv` (already a pixi dependency) and exercise the
+documented command, proving the pattern works rather than assuming it does.
+
+Two tests make a real network call, downloading the smallest real PDF and HTML "blank
+form"/"instructions" documents linked from live PUDL source documentation pages, to
+prove the conversion pattern against real PUDL resources (see references/data-sources.md
+for how these URLs are normally discovered). The other two tests convert locally
+generated .xlsx and .docx files -- binary, non-text formats PUDL doesn't itself
+distribute as documentation -- with no network call, to cover formats beyond PDF/HTML
+that agents may still run into (e.g. a user-supplied Word memo or spreadsheet).
+
+Run:  pixi run pytest dev/skills/pudl/tests/test_markitdown_conversion.py -v
+"""
+
+import subprocess
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+# Smallest instructions PDF found under any source's "Download additional
+# documentation" section (~120 KB) -- keeps the live download and PDF conversion fast.
+FERC714_INSTRUCTIONS_PDF_URL = (
+    "https://docs.catalyst.coop/pudl/en/nightly/_downloads/"
+    "f48d006b011903ae36c2e6a5acfb4f81/ferc714_instructions_2021-04-16.pdf"
+)
+
+# Smallest of the newest-edition (2025-07-31) HTML blank forms linked from ferc1.html's
+# "Download additional documentation" section (~1.3 MB).
+FERC3Q_ELECTRIC_HTML_URL = (
+    "https://docs.catalyst.coop/pudl/en/nightly/_downloads/"
+    "5fe9aad5d45a9f43e5b7a65cf0ad5e97/ferc3q_electric_2025-07-31.html"
+)
+
+
+@pytest.fixture(scope="module")
+def markitdown_venv(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build the throwaway venv the documented pattern calls for, once per module.
+
+    references/data-sources.md documents `uv pip install "markitdown[pdf,docx]"` into
+    a scratch environment rather than assuming markitdown is already present. This
+    fixture runs that pattern (plus the [xlsx] extra and python-docx, needed only to
+    generate the .xlsx/.docx fixtures below, not to run markitdown itself).
+    """
+    venv_dir = tmp_path_factory.mktemp("markitdown-venv")
+    subprocess.run(["uv", "venv", str(venv_dir)], check=True, capture_output=True)
+    subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(venv_dir),
+            "markitdown[pdf,xlsx,docx]",
+            "python-docx",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return venv_dir
+
+
+def _convert(markitdown_venv: Path, path: Path) -> str:
+    result = subprocess.run(
+        [str(markitdown_venv / "bin" / "markitdown"), str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _download(url: str, destination: Path) -> None:
+    # docs.catalyst.coop returns 403 for urllib's default User-Agent string; a
+    # non-empty one (as curl and browsers send by default) is accepted.
+    request = urllib.request.Request(url, headers={"User-Agent": "pudl-skill-tests"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        destination.write_bytes(response.read())
+
+
+def test_markitdown_converts_pdf(markitdown_venv: Path, tmp_path: Path) -> None:
+    """A real FERC filer-instructions PDF converts to readable markdown text."""
+    pdf_path = tmp_path / "ferc714_instructions.pdf"
+    _download(FERC714_INSTRUCTIONS_PDF_URL, pdf_path)
+
+    text = _convert(markitdown_venv, pdf_path)
+
+    assert "Form 714" in text
+    assert "Instructions" in text
+
+
+def test_markitdown_converts_html(markitdown_venv: Path, tmp_path: Path) -> None:
+    """A real FERC blank-form HTML edition converts to readable markdown text."""
+    html_path = tmp_path / "ferc3q_electric.html"
+    _download(FERC3Q_ELECTRIC_HTML_URL, html_path)
+
+    text = _convert(markitdown_venv, html_path)
+
+    assert "FERC FORM No. 1" in text
+
+
+def test_markitdown_converts_xlsx(markitdown_venv: Path, tmp_path: Path) -> None:
+    """A locally generated .xlsx -- a binary, non-text format -- also converts
+    cleanly, showing the same tool handles more than just PDF and HTML."""
+    xlsx_path = tmp_path / "sample.xlsx"
+    build_script = (
+        "import openpyxl\n"
+        "wb = openpyxl.Workbook()\n"
+        "ws = wb.active\n"
+        "ws['A1'] = 'plant'\n"
+        "ws['B1'] = 'capacity_mw'\n"
+        "ws['A2'] = 'Comanche'\n"
+        "ws['B2'] = 100.5\n"
+        f"wb.save({str(xlsx_path)!r})\n"
+    )
+    subprocess.run(
+        [str(markitdown_venv / "bin" / "python"), "-c", build_script],
+        check=True,
+        capture_output=True,
+    )
+
+    text = _convert(markitdown_venv, xlsx_path)
+
+    assert "Comanche" in text
+    assert "100.5" in text
+
+
+def test_markitdown_converts_docx(markitdown_venv: Path, tmp_path: Path) -> None:
+    """A locally generated .docx -- another binary, non-text format -- also converts
+    cleanly, e.g. for a user-supplied Word memo or errata document."""
+    docx_path = tmp_path / "sample.docx"
+    build_script = (
+        "import docx\n"
+        "d = docx.Document()\n"
+        "d.add_heading('FERC Form 1 Errata', level=1)\n"
+        "d.add_paragraph('Schedule 204 line 5 should reference Comanche station.')\n"
+        f"d.save({str(docx_path)!r})\n"
+    )
+    subprocess.run(
+        [str(markitdown_venv / "bin" / "python"), "-c", build_script],
+        check=True,
+        capture_output=True,
+    )
+
+    text = _convert(markitdown_venv, docx_path)
+
+    assert "FERC Form 1 Errata" in text
+    assert "Comanche" in text

--- a/docs/datapackage-skill.md
+++ b/docs/datapackage-skill.md
@@ -23,9 +23,11 @@ npx skills add catalyst-cooperative/agent-skills -s datapackage
 
 Querying metadata requires [`jq`](https://jqlang.org/) (>= 1.8). Loading data works with
 whatever's already in your environment: pandas or polars if you have Python set up, or
-DuckDB directly with no Python required at all (via the companion `attach-db` and
-`query` skills from [duckdb/duckdb-skills](https://github.com/duckdb/duckdb-skills), for
-pure-SQL workflows). Validating a package's structural integrity is optional and uses the
+DuckDB directly with no Python required at all (via the companion `attach-db`, `query`,
+and `install-duckdb` skills from
+[duckdb/duckdb-skills](https://github.com/duckdb/duckdb-skills) — `install-duckdb`
+surfaces the right install command for your platform if the DuckDB CLI itself isn't
+found). Validating a package's structural integrity is optional and uses the
 [`frictionless`](https://framework.frictionlessdata.io/) CLI if it's installed. See the
 [main README](https://github.com/catalyst-cooperative/agent-skills#installing) for other
 installation methods.

--- a/docs/pudl-skill.md
+++ b/docs/pudl-skill.md
@@ -40,9 +40,10 @@ for other installation methods.
     recommend and when to warn you off a preliminary table.
 - **FERC Form 1 and Form 2 lookups.** Resolving a schedule number ("Schedule 301"), a
     FERC account number, or a topic to the PUDL tables that cover it.
-- **Loading data.** Working pandas, DuckDB, or polars code to read Parquet directly
-    from PUDL's public S3 bucket (no credentials needed) or a local download, plus
-    locations for the FERC historical DuckDB/SQLite databases and the FERC EQR dataset.
+- **Loading data.** Working DuckDB (pure SQL, no Python required), polars, or pandas
+    code to read Parquet directly from PUDL's public S3 bucket (no credentials needed)
+    or a local download, plus locations for the raw per-form FERC Parquet directories
+    and the FERC EQR dataset.
 - **Pointing you at methodology.** For anything involving cleaning, imputation,
     allocation, or entity resolution, the agent looks at PUDL's own methodology
     write-ups before explaining implementation details.
@@ -63,7 +64,7 @@ over lower-tier alternatives.
 > "I want to load `out_eia923__yearly_generation` in a script. I don't have PUDL
 > installed locally — can I get it from S3?"
 
-The agent returns working pandas or DuckDB code reading straight from the public S3
+The agent returns working DuckDB or polars code reading straight from the public S3
 bucket, with no PUDL package import required, and shows column projection for large
 tables.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -151,6 +151,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.9.3-h53e704d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.48.0-hb17b654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.12.0-h2112641_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zensical-0.0.51-py310h1570de5_0.conda
@@ -376,6 +377,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/taplo-0.9.3-h112f5b8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typos-1.48.0-h069e38c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uv-0.12.0-hbe9c82f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wrapt-2.2.2-py314h51f160d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zensical-0.0.51-py310h81496b1_0.conda
@@ -691,6 +693,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.9.3-hf3953a5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hb794df6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/typos-1.48.0-h19f9e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.33-h0bcf9e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-2.2.2-py314h217eccc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zensical-0.0.51-py310habc1dbc_0.conda
@@ -912,6 +915,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.9.3-hdf53557_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.48.0-h6fdd925_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.12.0-h11277c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py314h6c2aa35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zensical-0.0.51-py310hf7b50e3_0.conda
@@ -2711,8 +2715,7 @@ packages:
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
   license_family: APACHE
-  purls:
-  - pkg:pypi/pyarrow?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 26040
   timestamp: 1784258391200
@@ -3012,6 +3015,20 @@ packages:
   run_exports: {}
   size: 3366192
   timestamp: 1782859608728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.12.0-h2112641_0.conda
+  sha256: a23f636a396719f3e35a8ffa746226b816b6927ac1917a5a64b3475052ac08e4
+  md5: bb7542991ddbe5ed9081b52b17c44887
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR MIT
+  purls: []
+  run_exports: {}
+  size: 17200367
+  timestamp: 1785302829729
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
   sha256: f2789ff73f60f3b740629146a64f778bbf40e26900978cb632180878a496423c
   md5: e1e275654a6c998b7357606f5da46af7
@@ -5089,6 +5106,19 @@ packages:
   run_exports: {}
   size: 3903453
   timestamp: 1782859635286
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uv-0.12.0-hbe9c82f_0.conda
+  sha256: c174f7912177eb905b5cf6dfe4539a9e5f4142d918a9614b76ce336daccadf3d
+  md5: adb392239f9e3205f42bfa08f19d0100
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR MIT
+  purls: []
+  run_exports: {}
+  size: 16975792
+  timestamp: 1785302806583
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wrapt-2.2.2-py314h51f160d_0.conda
   sha256: 9b17ad8c0b74930af2285636857456882ea2fc912163d0465dc3b0f76b477feb
   md5: bf43644f5d4f777755c046de12e50baa
@@ -5286,7 +5316,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/annotated-types?source=compressed-mapping
+  - pkg:pypi/annotated-types?source=hash-mapping
   run_exports: {}
   size: 19461
   timestamp: 1784935220549
@@ -5353,7 +5383,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/botocore?source=compressed-mapping
+  - pkg:pypi/botocore?source=hash-mapping
   run_exports: {}
   size: 8864109
   timestamp: 1783942209492
@@ -5570,7 +5600,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/fsspec?source=compressed-mapping
+  - pkg:pypi/fsspec?source=hash-mapping
   run_exports: {}
   size: 149709
   timestamp: 1781615868173
@@ -6230,7 +6260,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/s3fs?source=compressed-mapping
+  - pkg:pypi/s3fs?source=hash-mapping
   run_exports: {}
   size: 36232
   timestamp: 1781621673975
@@ -8422,6 +8452,19 @@ packages:
   run_exports: {}
   size: 2862431
   timestamp: 1782859665351
+- conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.33-h0bcf9e0_0.conda
+  sha256: 0e058cd8cbc372183258b990109f75e91bbba7b68ba46c0e18415e6a95cf5fbf
+  md5: 8ad4f13d17670e71f9e934a77a3d3d8d
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 OR MIT
+  purls: []
+  run_exports: {}
+  size: 15922853
+  timestamp: 1785262460088
 - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-2.2.2-py314h217eccc_0.conda
   sha256: 2085dc38327246bbf0c67623f68065ccd2ddaa72afa120389cd8302cf293f897
   md5: e7a69352489b8d51150a42825c9a64b4
@@ -10171,8 +10214,7 @@ packages:
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
   license_family: APACHE
-  purls:
-  - pkg:pypi/pyarrow?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 25915
   timestamp: 1784258318884
@@ -10269,7 +10311,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/duckdb?source=compressed-mapping
+  - pkg:pypi/duckdb?source=hash-mapping
   run_exports: {}
   size: 12062962
   timestamp: 1784912300585
@@ -10342,7 +10384,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 285627
   timestamp: 1782831308617
@@ -10455,6 +10497,19 @@ packages:
   run_exports: {}
   size: 2712152
   timestamp: 1782859631187
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.12.0-h11277c2_0.conda
+  sha256: 5a6584197304a5718440570b6248bf5df9021bf72701520feb6c658e6e47210a
+  md5: b21d973b33d6a3d662c3823df1828da2
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 OR MIT
+  purls: []
+  run_exports: {}
+  size: 14472837
+  timestamp: 1785302880272
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py314h6c2aa35_0.conda
   sha256: 3fff09a8c28dbdd3280c767f0b09ab5a25bcda2ed3b0a07b48a5b986e0ff12df
   md5: abca357e08d7ceaaeebafa6d7f5a7fad

--- a/pixi.lock
+++ b/pixi.lock
@@ -45,7 +45,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h720e601_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.40.1-h102d43b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.833-hc7390e0_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.36.8-py314h9e666f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.36.10-py314h9e666f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.36.0-py314h324e86d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
@@ -87,11 +87,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.7.0-hbc29df5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.7.0-hdbdcf42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.82.1-h792040b_0.conda
@@ -105,19 +105,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-25.0.0-h7376487_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-7.35.1-h2840a7c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-hf670292_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h60473fc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
@@ -127,8 +127,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.1-h443056b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py314hb4ffadd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-runtime-32-1.43.0-py310h9585f58_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.5-py314hb4ffadd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-runtime-32-1.43.1-py310h9585f58_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.4.11-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-hdf27b9d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
@@ -155,7 +155,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zensical-0.0.51-py310h1570de5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.8.0-pyhcf101f3_0.conda
@@ -163,7 +163,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.14.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
@@ -200,7 +200,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.1-h5ac6406_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/marko-2.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdformat-1.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdformat-footnote-0.1.3-pyhd8ed1ab_0.conda
@@ -210,11 +210,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/multidict-6.7.1-pyh62beb40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.21-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.0-pyh8da0edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.1-pyh8da0edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -271,7 +271,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.2.10-hbf34bff_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h18900c3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.833-h1131a43_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.36.8-py314h9dd9068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.36.10-py314h9dd9068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/awscrt-0.36.0-py314h1187f9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
@@ -313,11 +313,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.1.0-h205dda4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.1.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.1.0-he9431aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.1.0-h47adacf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.1.0-h8acb6b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-3.7.0-h2efc11c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.7.0-h66d5b86_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgrpc-1.82.1-h05b84e8_0.conda
@@ -331,19 +331,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-25.0.0-h87079af_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-7.35.1-h30ec8a2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h36cc0f4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-h149037f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.4-h022381a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-16.1.0-hef695bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-16.1.0-hdbbeba8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libthrift-0.22.0-ha522d1d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libutf8proc-2.11.3-hec6f9f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-16-2.15.3-h79dcc73_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.15.3-h869d058_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-3.0.3-py314hb76de3f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
@@ -353,8 +353,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/oniguruma-6.9.10-h86ecc28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orc-2.3.1-h1fb4f23_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-3.0.5-py314he6363bd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/polars-runtime-32-1.43.0-py310ha6a983b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-3.0.5-py314he6363bd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/polars-runtime-32-1.43.1-py310ha6a983b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/prek-0.4.11-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/prettier-3.9.3-ha6c2a1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/prometheus-cpp-1.3.0-h7938499_0.conda
@@ -381,7 +381,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/wrapt-2.2.2-py314h51f160d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zensical-0.0.51-py310h81496b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.8.0-pyhcf101f3_0.conda
@@ -389,7 +389,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.14.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
@@ -426,7 +426,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.1-h5ac6406_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/marko-2.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdformat-1.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdformat-footnote-0.1.3-pyhd8ed1ab_0.conda
@@ -436,11 +436,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/multidict-6.7.1-pyh62beb40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.21-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.0-pyh8da0edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.1-pyh8da0edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -488,7 +488,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.14.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
@@ -525,7 +525,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.1-h5ac6406_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/marko-2.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdformat-1.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdformat-footnote-0.1.3-pyhd8ed1ab_0.conda
@@ -535,11 +535,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/multidict-6.7.1-pyh62beb40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.21-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.0-pyh8da0edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.1-pyh8da0edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -591,7 +591,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.2.10-h83f6fd2_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.40.1-hfc09f7c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.833-hcd60bbe_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.36.8-py314h99aeb3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.36.10-py314h99aeb3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/awscrt-0.36.0-py314h20ed0b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.16.3-hce1ca1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.13.3-hfaa3f56_2.conda
@@ -633,9 +633,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.1.0-h13771c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.1.0-h7e5c614_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.1.0-h70d9f54_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.7.0-he806f76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-3.7.0-h1159701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.82.1-h00dac5a_0.conda
@@ -649,7 +649,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.27.0-h694c41f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-25.0.0-hd9337e7_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-7.35.1-h087ac9f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpsl-0.22.0-ha9fe4b0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpsl-0.22.0-h9bd203f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h962f25e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-h77d7759_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.1-hed3591d_0.conda
@@ -658,7 +658,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.10.0-h240833e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py314h77fa6c7_1.conda
@@ -669,8 +669,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-h6e16a3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.3.1-h982cfee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.3-py314h99bb933_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/polars-runtime-32-1.43.0-py310hbfc13ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.5-py314h99bb933_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/polars-runtime-32-1.43.1-py310hbfc13ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/prek-0.4.11-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h99b04b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
@@ -697,7 +697,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-2.2.2-py314h217eccc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zensical-0.0.51-py310habc1dbc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/c1/61/ae77d87133bd32c86631dcfb595a24432cec45d868c99b7e9b6b50597bf0/mdformat_simple_breaks-0.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/82/daa65a9a2fda6fc565b2143322a3e978c70ed92988bef2da5b90e7fc919c/mdformat_mkdocs-5.2.1-py3-none-any.whl
@@ -710,7 +710,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.14.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
@@ -747,7 +747,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.1-h5ac6406_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/marko-2.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdformat-1.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdformat-footnote-0.1.3-pyhd8ed1ab_0.conda
@@ -757,11 +757,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/multidict-6.7.1-pyh62beb40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.20-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.21-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.0-pyh8da0edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.1-pyh8da0edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
@@ -813,7 +813,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.2.10-hf0b4b85_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-h5b5d287_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.833-haa98fb3_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.36.8-py314hcec6336_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.36.10-py314hcec6336_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscrt-0.36.0-py314h6366067_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
@@ -855,9 +855,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.1.0-h3cf6597_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.1.0-h07b0088_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.1.0-h32cdfcc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.7.0-ha595bda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-3.7.0-hc8aed40_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.82.1-hf3e839d_0.conda
@@ -871,7 +871,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-25.0.0-h0de02aa_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-h92480b3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-h7a62e17_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h5d15848_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
@@ -880,7 +880,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
@@ -892,7 +892,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.1-hef2a647_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.5-py314he609de1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-runtime-32-1.43.0-py310hcbcba24_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-runtime-32-1.43.1-py310hcbcba24_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.4.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-he13c965_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
@@ -919,7 +919,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py314h6c2aa35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zensical-0.0.51-py310hf7b50e3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/c1/61/ae77d87133bd32c86631dcfb595a24432cec45d868c99b7e9b6b50597bf0/mdformat_simple_breaks-0.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d8/82/daa65a9a2fda6fc565b2143322a3e978c70ed92988bef2da5b90e7fc919c/mdformat_mkdocs-5.2.1-py3-none-any.whl
@@ -1185,9 +1185,9 @@ packages:
     - aws-sdk-cpp >=1.11.833,<1.11.834.0a0
   size: 3394321
   timestamp: 1784137257627
-- conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.36.8-py314h9e666f3_0.conda
-  sha256: a8df1b978e30fb84d3c34f7957665541a645268a419edeaa7aba5728f64b7bca
-  md5: 0efd5ffbc6d09da193b5cf76756f643b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.36.10-py314h9e666f3_0.conda
+  sha256: 07606ace2f8d5a6d803a8a3467e404a6bc94019dc56ac139c3363dc3d886a864
+  md5: c490696147a315bce129e353df9a2278
   depends:
   - python
   - colorama >=0.2.5,<0.4.7
@@ -1203,12 +1203,11 @@ packages:
   - wcwidth <0.3.0
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/awscli?source=hash-mapping
   run_exports: {}
-  size: 15730443
-  timestamp: 1784970197581
+  size: 15732546
+  timestamp: 1785310363377
 - conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.36.0-py314h324e86d_0.conda
   sha256: 72d0cc5322baf8ce8a324abf3608568626cfd8b6de66706dc30c804e43a817cc
   md5: aff5a68be1e3263332884e21e76b6787
@@ -1459,6 +1458,7 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   license: BSD-3-Clause
+  license_family: BSD
   purls: []
   run_exports:
     weak:
@@ -1911,74 +1911,69 @@ packages:
     - libffi >=3.5.2,<3.6.0a0
   size: 58592
   timestamp: 1769456073053
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_20.conda
-  sha256: e3b7bb287d1685b15781a6d9e3408d6ddaff23f5a1d0d6c0140619dd3950fe72
-  md5: 3533de187cf7283f96bfdb28ad73e2bc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+  sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+  md5: 5a7d954665c707c93311657cd779c705
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 15.2.0 he0feb66_20
-  - libgcc-ng ==15.2.0=*_20
+  - libgomp 16.1.0 he0feb66_1
+  - libgcc-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 1041122
-  timestamp: 1784923795784
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_20.conda
-  sha256: e01a2a027fceea1011d2e74307845fb0c4bd6d195ff27fbf5baeafa55531d128
-  md5: c099368d009e4d828449eaed7b2cb701
+  size: 1057877
+  timestamp: 1785375436766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+  sha256: 225275c562337a1cd61705da0ee4235dde7bba7504de1c34b74c894adb2b0eee
+  md5: 7ed870c014a6f23c7dfafda53d2763a9
   depends:
-  - libgcc 15.2.0 he0feb66_20
+  - libgcc 16.1.0 ha9f2e26_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports:
     strong:
     - libgcc
-  size: 28129
-  timestamp: 1784923800003
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_20.conda
-  sha256: 76d81032e264b74f519cc26962d5eb39547e0785fc9d2957bbc12e7a91214412
-  md5: a450a08a63f940e9aa7b37692e71196a
+  size: 28210
+  timestamp: 1785375440733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+  sha256: 9e82d410a50bd4e5e47cbbb026454c3eb543954baca4db23929575b571bf56a3
+  md5: 2fbed65cc90cf0724e1ec4de13696737
   depends:
-  - libgfortran5 15.2.0 h68bc16d_20
+  - libgfortran5 16.1.0 h79bb938_1
   constrains:
-  - libgfortran-ng ==15.2.0=*_20
+  - libgfortran-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 28103
-  timestamp: 1784923831860
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_20.conda
-  sha256: 95122f42566dc9a62b9615d2372b3f3c75fa7bd8bb1eda53aa7532ce60d545eb
-  md5: 4edbcbea1a8790a7d58e648523b69546
+  size: 28134
+  timestamp: 1785375470055
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+  sha256: 05078ab464d506dff971860cb1a553b35bc27c0b5ce8ec29b8bfaca5f2359652
+  md5: dd51ed33e8c70995f8e33cc9dc537297
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=15.2.0
+  - libgcc >=16.1.0
   constrains:
-  - libgfortran 15.2.0
+  - libgfortran 16.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 2483727
-  timestamp: 1784923810904
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_20.conda
-  sha256: 30b8ff1bf43871a17c9de99e56171ef54cfbe690ffa86681628db5a00af97cf7
-  md5: 49321086c41bb58fc4b6cd8cbb74679d
+  size: 2538696
+  timestamp: 1785375448623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+  md5: 88f2d91cb1533194c323534253094d23
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports:
     strong:
     - _openmp_mutex >=4.5
-  size: 603998
-  timestamp: 1784923730278
+  size: 640415
+  timestamp: 1785375373755
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.7.0-hbc29df5_0.conda
   sha256: 5e6186a18c868651f9f7d8ed5b9ff0c808294b33f5ae56f7f97ccd3d75f96c9d
   md5: 767b70cdcd4bd5547be6db59a5f8c897
@@ -2214,22 +2209,22 @@ packages:
     - libprotobuf >=7.35.1,<7.35.2.0a0
   size: 3774596
   timestamp: 1783168720126
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
-  sha256: 71118885feab91c61bea4e9532ec46e0653b24f02e563681f822915aee8435bb
-  md5: af5ddfb52ad25d833c70c7511478d4eb
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-hf670292_2.conda
+  sha256: a9fcbf3d64be6e0c587dd6135f6d720e1569972692d42bff6c013cd5056ac23d
+  md5: f4bb2168fb76b16a31ac27e0a372d2e3
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.3,<79.0a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
+  - icu >=78.3,<79.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
     - libpsl >=0.22.0,<0.23.0a0
-  size: 70092
-  timestamp: 1783936855082
+  size: 72299
+  timestamp: 1785342673105
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h60473fc_2.conda
   sha256: 43132eb45a569b1f63199b0e7d5874d94227e9be950b327a323e7dcc1f8cd58c
   md5: ee5c400d37b79db5d32a69ed1a79fc0b
@@ -2280,33 +2275,31 @@ packages:
     - libssh2 >=1.11.1,<2.0a0
   size: 304790
   timestamp: 1745608545575
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_20.conda
-  sha256: b5eadda8fb0df262f0d424c4a0c8c1c8d65d904ce622f07936c793ea1b8a39d9
-  md5: fbd3d5506b11b5cfc916b29263b6b6f7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+  md5: aed6cf89adc1e9b846e4367ac538e434
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 he0feb66_20
+  - libgcc 16.1.0 ha9f2e26_1
   constrains:
-  - libstdcxx-ng ==15.2.0=*_20
+  - libstdcxx-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 5857690
-  timestamp: 1784923825011
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_20.conda
-  sha256: 0b79903234f68410c11c33cb9829f7b3cb01a9ff2f42bf083dd2c51e886e6077
-  md5: 593dc263426eb14f16dc594bfdb9772a
+  size: 6631744
+  timestamp: 1785375462643
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+  sha256: 2876ca4463d1b394eb969ce4a84d1620aa63fb8202a6397837d1e45ec76c1208
+  md5: c94f06123272d8e129d4acf3a25ffb35
   depends:
-  - libstdcxx 15.2.0 h934c35e_20
+  - libstdcxx 16.1.0 h934c35e_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports:
     strong:
     - libstdcxx
-  size: 28191
-  timestamp: 1784923863263
+  size: 28253
+  timestamp: 1785375500257
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
   sha256: af6025aa4a4fc3f4e71334000d2739d927e2f678607b109ec630cc17d716918a
   md5: b6e326fbe1e3948da50ec29cee0380db
@@ -2405,21 +2398,21 @@ packages:
     - libxml2-16 >=2.15.3
   size: 46810
   timestamp: 1776376751152
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
-  md5: d87ff7921124eccd67248aa483c23fec
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
   depends:
   - __glibc >=2.17,<3.0.a0
   constrains:
-  - zlib 1.3.2 *_2
+  - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
   purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
-  size: 63629
-  timestamp: 1774072609062
+  size: 63713
+  timestamp: 1785362952714
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   md5: 9de5350a85c4a20c685259b889aa6393
@@ -2579,9 +2572,9 @@ packages:
     - orc >=2.3.1,<2.3.2.0a0
   size: 1458252
   timestamp: 1784301236872
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py314hb4ffadd_0.conda
-  sha256: 8e4b161f3f7fbdf17f842b518ff3794b6af9378a90d095719d7153360d126dc1
-  md5: bc2e1390314b1269e66fb1966fbcae5d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.5-py314hb4ffadd_1.conda
+  sha256: b8197d816dfef2e237c45e875d7e37d125c1e12af819a911dcfd95c2cb98a010
+  md5: 15cd0f375b79b47c4048e44396e6e6f1
   depends:
   - python
   - numpy >=1.26.0
@@ -2631,32 +2624,30 @@ packages:
   - xlsxwriter >=3.2.0
   - zstandard >=0.23.0
   license: BSD-3-Clause
-  license_family: BSD
   purls:
   - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
-  size: 15303815
-  timestamp: 1778602611222
-- conda: https://conda.anaconda.org/conda-forge/linux-64/polars-runtime-32-1.43.0-py310h9585f58_0.conda
+  size: 15360863
+  timestamp: 1785276230218
+- conda: https://conda.anaconda.org/conda-forge/linux-64/polars-runtime-32-1.43.1-py310h9585f58_0.conda
   noarch: python
-  sha256: 7d9813719a8c1729992e7788a2df8cce59941fb7c7f9e34cb65a44fafdb12905
-  md5: 704dc356be6ee9942bf2f5d6285f6c9c
+  sha256: ecf89706db67c56ca40f368761a37b5a27cc7bb0f3a2c2bc2236868a6e0ac13d
+  md5: 40a1d4947477e74a5ddcdbd5e825af61
   depends:
   - python
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
   - _python_abi3_support 1.*
   - cpython >=3.10
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/polars-runtime-32?source=hash-mapping
+  - pkg:pypi/polars-runtime-32?source=compressed-mapping
   run_exports: {}
-  size: 41196069
-  timestamp: 1784642533849
+  size: 41636506
+  timestamp: 1785183544670
 - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.4.11-hb17b654_0.conda
   sha256: 5dbc28702d5b36f7277062657efe9ab7ba6fa9946c9a7f5a6d59f69e3e052987
   md5: cf2e7d19213258128fab87be6481a968
@@ -3085,20 +3076,20 @@ packages:
   run_exports: {}
   size: 6905096
   timestamp: 1784341093483
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
-  sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
-  md5: c2a01a08fc991620a74b32420e97868a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+  sha256: 16080a1c7724f7d25727cdc23c7658e0cec2db52448c1dc0c33467ee2c6e1c62
+  md5: 6acb86426229f96f93e5468d1df3a5e8
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libzlib 1.3.2 h25fd6f3_2
+  - libzlib 1.3.2 h25fd6f3_3
   license: Zlib
   license_family: Other
   purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
-  size: 95931
-  timestamp: 1774072620848
+  size: 96132
+  timestamp: 1785362957588
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
@@ -3356,9 +3347,9 @@ packages:
     - aws-sdk-cpp >=1.11.833,<1.11.834.0a0
   size: 3343033
   timestamp: 1784137273922
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.36.8-py314h9dd9068_0.conda
-  sha256: 5c502ef66933525b1370a5b71a943a8b7f82ddc25149fe048499763afdab7523
-  md5: 1715106af625608d92ec0618854842c6
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/awscli-2.36.10-py314h9dd9068_0.conda
+  sha256: 914c053916768e28c728b6c3155b4421a6ade5c99a3bbb3620ea16ec5db331b1
+  md5: f340798bad29c7dc4ef73a0ae86a8e38
   depends:
   - python
   - colorama >=0.2.5,<0.4.7
@@ -3375,12 +3366,11 @@ packages:
   - python 3.14.* *_cp314
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/awscli?source=hash-mapping
   run_exports: {}
-  size: 15736615
-  timestamp: 1784970196980
+  size: 15738725
+  timestamp: 1785310392374
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/awscrt-0.36.0-py314h1187f9e_0.conda
   sha256: 902bf1fd57acf627b21d35e34c915d5c43e2dab0845e47d31df579a2bb0ecc5e
   md5: dc7f5a438831e6cbde7ecf8356e9a642
@@ -3622,6 +3612,7 @@ packages:
   - libgcc >=14
   - libstdcxx >=14
   license: BSD-3-Clause
+  license_family: BSD
   purls: []
   run_exports:
     weak:
@@ -4054,70 +4045,65 @@ packages:
     - libffi >=3.5.2,<3.6.0a0
   size: 55952
   timestamp: 1769456078358
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_20.conda
-  sha256: b8274208cff283551c1a0eaa0f8970ee58bb954f96cd270dfc30ebeb355e6ca3
-  md5: 44728537e108c9dc60f4dd78efdd6f5b
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.1.0-h205dda4_1.conda
+  sha256: 88a3d400c678df034c9d498f32503779977d5ea826063687c663e42c945abed5
+  md5: 91eb209af1098d652fc69b8a3fc7cbaa
   depends:
   - _openmp_mutex >=4.5
   constrains:
-  - libgcc-ng ==15.2.0=*_20
-  - libgomp 15.2.0 h8acb6b2_20
+  - libgomp 16.1.0 h8acb6b2_1
+  - libgcc-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 622148
-  timestamp: 1784923847629
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_20.conda
-  sha256: 4778b29114359381f0582d1dbfb82933a08ecac356d7c380d7f1203e159f6a7c
-  md5: cf5cfbe0da529b6df258b9fe2efc9033
+  size: 628785
+  timestamp: 1785374520532
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.1.0-he9431aa_1.conda
+  sha256: e0456b4b49e8f9f9ffc04b1b412101ea2c38476eaceb9a0e4e16792d7cfdd929
+  md5: e4489d8717b51cee8a33f2b66d10fa6a
   depends:
-  - libgcc 15.2.0 h8acb6b2_20
+  - libgcc 16.1.0 h205dda4_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports:
     strong:
     - libgcc
-  size: 28294
-  timestamp: 1784923850746
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_20.conda
-  sha256: df718f4740678be387a7fef69f07c2a6018355b224980bfbf8becd460b61fc1c
-  md5: 9a2cdf6a72609803793099767719e962
+  size: 28123
+  timestamp: 1785374523851
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.1.0-he9431aa_1.conda
+  sha256: 2cef8ffd270434043daf8f481d0c64d3285286e5d3e7c3d43770fec93eddac05
+  md5: 8ae8f954eb026b1f0734bea5f9fdfca2
   depends:
-  - libgfortran5 15.2.0 h1b7bec0_20
+  - libgfortran5 16.1.0 h47adacf_1
   constrains:
-  - libgfortran-ng ==15.2.0=*_20
+  - libgfortran-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 28269
-  timestamp: 1784923880524
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_20.conda
-  sha256: 0520a811cf2dde6778ab53b68a8b463fa3886299ebe2af0a63974d372949d078
-  md5: f898c9d13cc66fbf7d4587e0cb274bfb
+  size: 28122
+  timestamp: 1785374551480
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.1.0-h47adacf_1.conda
+  sha256: abf2248fd6b2863dc3c9eade2dcf1f7e0662334e9a6f211af1816c166dc45a93
+  md5: ad336824ac53098bf5004b2fa080467e
   depends:
-  - libgcc >=15.2.0
+  - libgcc >=16.1.0
   constrains:
-  - libgfortran 15.2.0
+  - libgfortran 16.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 1487067
-  timestamp: 1784923860848
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_20.conda
-  sha256: 053c48747858d726f3236e7674c0e98fd0c50aed83c5389f8f3154bd24f459f2
-  md5: 694ef02da1f41b8696e7624d0648261f
+  size: 1496461
+  timestamp: 1785374532738
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.1.0-h8acb6b2_1.conda
+  sha256: 1c609a4a72597350317b92c4d9dfb85d21740219048e2b1d458925a6ccfa3d7a
+  md5: 4c9b02fc9fe27704777e260157003653
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports:
     strong:
     - _openmp_mutex >=4.5
-  size: 588465
-  timestamp: 1784923773482
+  size: 617180
+  timestamp: 1785374444877
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-3.7.0-h2efc11c_0.conda
   sha256: 24d035a426ee193619742ce66af8a5c019e29ec1f6d3c6a837e6143c3f339701
   md5: ca0ea0b9edd89d9976070a4e7c815928
@@ -4343,21 +4329,21 @@ packages:
     - libprotobuf >=7.35.1,<7.35.2.0a0
   size: 3597785
   timestamp: 1783168080031
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
-  sha256: 15ec553e784f2b8601c3df58e1dbe723309303c5ed405bc671bffae722c81023
-  md5: f8f91448e5ba30051ceb17b45b31da9b
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h36cc0f4_2.conda
+  sha256: 8b50e5d457749b082338b01c8627774ffefe3eece6c6f9b984e947a8c24c77ad
+  md5: 47afdf763422a5af207655265caed647
   depends:
-  - icu >=78.3,<79.0a0
-  - libgcc >=14
   - libstdcxx >=14
+  - libgcc >=14
+  - icu >=78.3,<79.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
     - libpsl >=0.22.0,<0.23.0a0
-  size: 71121
-  timestamp: 1783936885865
+  size: 74498
+  timestamp: 1785342703953
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-h149037f_2.conda
   sha256: f50695291bfaf2aebe8795caae5e341af9ad3ff6d945c026cf01ca697a6620f4
   md5: f2ff51cd816045533d79c157acaf8e51
@@ -4404,32 +4390,30 @@ packages:
     - libssh2 >=1.11.1,<2.0a0
   size: 311396
   timestamp: 1745609845915
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_20.conda
-  sha256: 148c9c01c4fc647c98b0972397c9c51e8e83235355e22913d3acc2ee5c86a447
-  md5: 557580b03327077bcd8fca6dd4b893c6
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-16.1.0-hef695bb_1.conda
+  sha256: 81ef9a10a0e01ffc7e03d429ed048410153411b2d8bbf95c334bdf3dcf175ab0
+  md5: 0bfd287b881e05351a01c7ebf7bf8f1b
   depends:
-  - libgcc 15.2.0 h8acb6b2_20
+  - libgcc 16.1.0 h205dda4_1
   constrains:
-  - libstdcxx-ng ==15.2.0=*_20
+  - libstdcxx-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 5543885
-  timestamp: 1784923873334
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-15.2.0-hdbbeba8_20.conda
-  sha256: 1a6c017c1f9f4801609ff212d2cdda269ae3da7e3883d92a105b46bc5c2ea6c7
-  md5: a61bd2704c5fb5842d7ba9eed609407f
+  size: 6255794
+  timestamp: 1785374543663
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-16.1.0-hdbbeba8_1.conda
+  sha256: cb88eb500022e01f835209e771d455d2296e10a18a749f518c257dfcab7d46ba
+  md5: a728408241f9db99bad0d1642c908714
   depends:
-  - libstdcxx 15.2.0 hef695bb_20
+  - libstdcxx 16.1.0 hef695bb_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports:
     strong:
     - libstdcxx
-  size: 28367
-  timestamp: 1784923909760
+  size: 28182
+  timestamp: 1785374577436
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libthrift-0.22.0-ha522d1d_2.conda
   sha256: c43ccf2e53750a84962c2440359ec54fed01b36838d0a08e36f4b294c7d837a6
   md5: 6ecb1ee3cbccd5c3b9ba044e24515153
@@ -4522,19 +4506,19 @@ packages:
     - libxml2-16 >=2.15.3
   size: 48101
   timestamp: 1776376766341
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
-  sha256: eb111e32e5a7313a5bf799c7fb2419051fa2fe7eff74769fac8d5a448b309f7f
-  md5: 502006882cf5461adced436e410046d1
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_3.conda
+  sha256: 76efa6cc9d7e6f5ee3bbca0939f64054af2bdfb3c3632531f8e633cf6c2ea41e
+  md5: bd534c2fbe56d8c2ea3b2d8f5e12bca8
   constrains:
-  - zlib 1.3.2 *_2
+  - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
   purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
-  size: 69833
-  timestamp: 1774072605429
+  size: 70108
+  timestamp: 1785276540870
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
   sha256: 67e55058d275beea76c1882399640c37b5be8be4eb39354c94b610928e9a0573
   md5: 6654e411da94011e8fbe004eacb8fe11
@@ -4687,16 +4671,16 @@ packages:
     - orc >=2.3.1,<2.3.2.0a0
   size: 1440426
   timestamp: 1784301242846
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-3.0.5-py314he6363bd_0.conda
-  sha256: 551d58937c06ba8b475b85f088e35bbadf2e8f45afe8def27544c34fc77b75ad
-  md5: c73296c9bb1fc1cdabf1d1978d8eaf12
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-3.0.5-py314he6363bd_1.conda
+  sha256: 340d8d2dd47aaef41bf900b38b6fc114ef376559abc995a977ca48c29d6d2c97
+  md5: d95c780b73f559f4f728e913de7eb7aa
   depends:
   - python
   - numpy >=1.26.0
   - python-dateutil >=2.8.2
-  - python 3.14.* *_cp314
   - libstdcxx >=14
   - libgcc >=14
+  - python 3.14.* *_cp314
   - numpy >=1.23,<3
   - python_abi 3.14.* *_cp314
   constrains:
@@ -4739,16 +4723,15 @@ packages:
   - xlsxwriter >=3.2.0
   - zstandard >=0.23.0
   license: BSD-3-Clause
-  license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
-  size: 15184630
-  timestamp: 1784821753723
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/polars-runtime-32-1.43.0-py310ha6a983b_0.conda
+  size: 15190666
+  timestamp: 1785276250510
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/polars-runtime-32-1.43.1-py310ha6a983b_0.conda
   noarch: python
-  sha256: 5fa6ae249ac6d423a499c3f52d885e18eda7dc6921ebd4f14b870b3829b537d9
-  md5: bb1133c4277a28f45a7901750a8bd705
+  sha256: bb6428ad5e389507a0767edbfe032745b29d3c3776cd06d7de4e0c1237f38a79
+  md5: 31e9bc5fbd1391dd9d3bc8966fd773de
   depends:
   - python
   - libstdcxx >=14
@@ -4758,12 +4741,11 @@ packages:
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/polars-runtime-32?source=hash-mapping
   run_exports: {}
-  size: 37760742
-  timestamp: 1784642339240
+  size: 38359455
+  timestamp: 1785183494962
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/prek-0.4.11-h069e38c_0.conda
   sha256: aa2356c60796184173a8992bf0c3c0e6c859faeb8d05315722ff46a0223d3e17
   md5: 3e913d67cdc1361d22fbcf5600730147
@@ -5173,19 +5155,19 @@ packages:
   run_exports: {}
   size: 6788626
   timestamp: 1784341097575
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
-  sha256: d651731b45f2d84591881da3ce3e4107a9ba6709fe790dbd5f7b8d9c89a02ed7
-  md5: 493587274c81b34d198b085b46a86eaa
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_3.conda
+  sha256: 3f3c296477cf26474660942f4d8ec104a8eee2cb1abc7c5bfec9ac1102c66451
+  md5: 254c54ac18eca7bf4f865e661306dc43
   depends:
-  - libzlib 1.3.2 hdc9db2a_2
+  - libzlib 1.3.2 hdc9db2a_3
   license: Zlib
   license_family: Other
   purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
-  size: 100515
-  timestamp: 1774072641977
+  size: 100332
+  timestamp: 1785276566528
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   sha256: 569990cf12e46f9df540275146da567d9c618c1e9c7a0bc9d9cfefadaed20b75
   md5: c3655f82dcea2aa179b291e7099c1fcc
@@ -5294,19 +5276,18 @@ packages:
   run_exports: {}
   size: 13688
   timestamp: 1751626573984
-- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
-  sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
-  md5: 52be5139047efadaeeb19c6a5103f92a
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+  sha256: a0a320c709fded9b5178108dedebf81a1f5a5d9c7720e3af50c1ab058dadd296
+  md5: d68ec17cb915cab4642357417ec0a104
   depends:
   - python >=3.10
   - python
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/annotated-doc?source=hash-mapping
+  - pkg:pypi/annotated-doc?source=compressed-mapping
   run_exports: {}
-  size: 14222
-  timestamp: 1762868213144
+  size: 16785
+  timestamp: 1785335690199
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
   sha256: b8fcb994134d3918d1c64a9d62f4168ff85d5bfb89e698102fe4ed679fe0df24
   md5: 108c928d2a8551832dbc762b535e90bb
@@ -5790,17 +5771,16 @@ packages:
   run_exports: {}
   size: 69017
   timestamp: 1778169663339
-- conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.1-h5ac6406_0.conda
-  sha256: a96fa194449e5d903684a4d5099e1465e30ab50e38e0746337b53bb3531355f5
-  md5: d77a60eac4275f518626c88a50c20745
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
+  sha256: 08d5b94d9ebc34b3ccf7155737acb9dc67be5ef6f1f6b987dbf3249333d701c9
+  md5: d5393b1764b14e83a94fc4fc9174cf65
   depends:
   - nodejs
   license: MIT
-  license_family: MIT
   purls: []
   run_exports: {}
-  size: 2233224
-  timestamp: 1784297658364
+  size: 2241022
+  timestamp: 1785154531757
 - conda: https://conda.anaconda.org/conda-forge/noarch/marko-2.2.3-pyhd8ed1ab_0.conda
   sha256: 637bd698c470b33f01339f282f9b9d1080c364b49783d938e6d6e27f21a8f81c
   md5: 5765726ab7f662c4105e209ad3b542c9
@@ -5927,18 +5907,17 @@ packages:
   run_exports: {}
   size: 91574
   timestamp: 1777103621679
-- conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.20-pyhd8ed1ab_0.conda
-  sha256: 8320505d0af286f6066c7a8217c99e448f0ce31722842ad29381e5683f7b23f5
-  md5: 7d097f2dd526889d1f357457fb12f395
+- conda: https://conda.anaconda.org/conda-forge/noarch/petl-1.7.21-pyhd8ed1ab_0.conda
+  sha256: bc1272f5c8c95c15cd0f30401afdbf6de7cd3951f3b565febe596bec6128050b
+  md5: a0bedf36745e1dbd5043d3b229c4c362
   depends:
   - python >=3.6
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/petl?source=hash-mapping
   run_exports: {}
-  size: 321697
-  timestamp: 1784610895357
+  size: 321129
+  timestamp: 1785218549768
 - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
   sha256: f58a03dd2908c15dc65fab7e03a0212c69043466f7f85a4e345470492841782f
   md5: 293c4719f6d62778ffecd18e024a8fcd
@@ -5984,11 +5963,11 @@ packages:
   run_exports: {}
   size: 25877
   timestamp: 1764896838868
-- conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.0-pyh8da0edf_0.conda
-  sha256: fc25471f8e0e84fb51bc728ac31804a6e4bbd199b1a1a74bc1142274ca9623c8
-  md5: d12abc4e1aa8448d67f9399692f5489e
+- conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.1-pyh8da0edf_0.conda
+  sha256: d8fa4005313d1d50334125e386b145363d6a8ed44536cb0c1c90e1b6c0234ca1
+  md5: 9c6d8ce81180e3c862b59fde960b0377
   depends:
-  - polars-runtime-32 ==1.43.0
+  - polars-runtime-32 ==1.43.1
   - python >=3.10
   - python
   constrains:
@@ -6002,16 +5981,15 @@ packages:
   - pyiceberg >=0.7.1
   - altair >=5.4.0
   - great_tables >=0.8.0
-  - polars-runtime-32 ==1.43.0
-  - polars-runtime-64 ==1.43.0
-  - polars-runtime-compat ==1.43.0
+  - polars-runtime-32 ==1.43.1
+  - polars-runtime-64 ==1.43.1
+  - polars-runtime-compat ==1.43.1
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/polars?source=hash-mapping
   run_exports: {}
-  size: 547772
-  timestamp: 1784642533849
+  size: 548247
+  timestamp: 1785183544670
 - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
   sha256: ebc1bb62ac612af6d40667da266ff723662394c0ca78935340a5b5c14831227b
   md5: d17ae9db4dc594267181bd199bf9a551
@@ -6426,7 +6404,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/typing-extensions?source=compressed-mapping
+  - pkg:pypi/typing-extensions?source=hash-mapping
   run_exports: {}
   size: 52631
   timestamp: 1783002732887
@@ -6749,9 +6727,9 @@ packages:
     - aws-sdk-cpp >=1.11.833,<1.11.834.0a0
   size: 3011638
   timestamp: 1784137319923
-- conda: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.36.8-py314h99aeb3b_0.conda
-  sha256: 3f98a05ad1dc359313aba4dc1f04119617eb22d214b160a523dd7d91662995c5
-  md5: 3ee3d315ffa7769d8476693c15acb9ff
+- conda: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.36.10-py314h99aeb3b_0.conda
+  sha256: 250983c2e0bb16398563128de3876fcb2cffef38097663ade3ffc9af872b9f7b
+  md5: b29077705aaa4c14d565c9967e90972e
   depends:
   - python
   - colorama >=0.2.5,<0.4.7
@@ -6767,12 +6745,11 @@ packages:
   - wcwidth <0.3.0
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/awscli?source=hash-mapping
   run_exports: {}
-  size: 15729775
-  timestamp: 1784970365247
+  size: 15731518
+  timestamp: 1785311268540
 - conda: https://conda.anaconda.org/conda-forge/osx-64/awscrt-0.36.0-py314h20ed0b2_0.conda
   sha256: aa6791848380663f79e495385649734ee2facf25a5733eaec2a7280b0fc9054f
   md5: b6429ad6c46570bfeefa91014cb10ba5
@@ -7009,6 +6986,7 @@ packages:
   - __osx >=11.0
   - libcxx >=19
   license: BSD-3-Clause
+  license_family: BSD
   purls: []
   run_exports:
     weak:
@@ -7448,46 +7426,43 @@ packages:
     - libffi >=3.5.2,<3.6.0a0
   size: 53583
   timestamp: 1769456300951
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_20.conda
-  sha256: 62f5ffca25fa9ca586179a5ad738c5a58ba1e146d523efa09cd1c2b332c304ac
-  md5: 1584a9045b65fb73d0efe653f3f60c2d
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.1.0-h13771c8_0.conda
+  sha256: 7d43fb42dc3723f8c571fe3dc3237e4773a8a6e04b1ddf21a79dfe55c95d00ed
+  md5: 6320d0119a8435385973523d6ef36aa5
   depends:
   - _openmp_mutex
   constrains:
-  - libgcc-ng ==15.2.0=*_20
-  - libgomp 15.2.0 20
+  - libgomp 16.1.0 0
+  - libgcc-ng ==16.1.0=*_0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 425328
-  timestamp: 1784926120859
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_20.conda
-  sha256: 7dc5d70d9b10f65c848c37e4d8d3256719a5648dadaf39c848aeba899ea52d6e
-  md5: 62177155326072b1203cfa6f8bbe8962
+  size: 389873
+  timestamp: 1785284121801
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.1.0-h7e5c614_0.conda
+  sha256: 686fe76208a606e6cc78bb839d4894aeffd413e5433a41659fd5ab8fb1c4df04
+  md5: 13aba9e2f90752138dd6aa097b8b2eaa
   depends:
-  - libgfortran5 15.2.0 hd16e46c_20
+  - libgfortran5 16.1.0 h70d9f54_0
   constrains:
-  - libgfortran-ng ==15.2.0=*_20
+  - libgfortran-ng ==16.1.0=*_0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 140549
-  timestamp: 1784926290991
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_20.conda
-  sha256: 8ff9895cba6057b12d859b16c707b4b9dc573f43b30a5ff7b7853c23fae7a3d6
-  md5: e88f784ef827581e5e56f54acd74d55f
+  size: 98543
+  timestamp: 1785284406246
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.1.0-h70d9f54_0.conda
+  sha256: c65720c48ce6e453f057025814e4e2f51c07d5db50c3c681b7e4e1c9e34bee81
+  md5: 5bfc6bd27c3649656ee5433177de6f9a
   depends:
-  - libgcc >=15.2.0
+  - libgcc >=16.1.0
   constrains:
-  - libgfortran 15.2.0
+  - libgfortran 16.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 1064101
-  timestamp: 1784926130379
+  size: 1033154
+  timestamp: 1785284137141
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.7.0-he806f76_0.conda
   sha256: e72a62cb6aa804f57e99b4453b7111f7ec8bd3477d992aeb32817d9541f595c7
   md5: a907ff8020238b360f5cd72694dbf3d7
@@ -7718,21 +7693,21 @@ packages:
     - libprotobuf >=7.35.1,<7.35.2.0a0
   size: 2875966
   timestamp: 1783169173397
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libpsl-0.22.0-ha9fe4b0_1.conda
-  sha256: fe9e283a3b404b5c11429b15a9628003033f015a275985956528b74aae5e3e85
-  md5: 372870287bccae5d1696e6f5533f4937
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libpsl-0.22.0-h9bd203f_2.conda
+  sha256: 199133400fe8edc2e15064d5f70d25ff50a10b9155db14447c80b86de0a085a4
+  md5: 09fb9eabe53830533cf09b2edeaba2c8
   depends:
+  - libcxx >=19
   - __osx >=11.0
   - icu >=78.3,<79.0a0
-  - libcxx >=19
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
     - libpsl >=0.22.0,<0.23.0a0
-  size: 68134
-  timestamp: 1783937592205
+  size: 72548
+  timestamp: 1785342876835
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h962f25e_2.conda
   sha256: 14d969728d8bc26317984b652e2f03934f0ffc7f61d9ed229ec457e9be95c587
   md5: 03c9286e5fb44ae19924b0ace236f7cd
@@ -7858,21 +7833,21 @@ packages:
     - libxml2-16 >=2.15.3
   size: 40836
   timestamp: 1776377277986
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
-  sha256: 4c6da089952b2d70150c74234679d6f7ac04f4a98f9432dec724968f912691e7
-  md5: 30439ff30578e504ee5e0b390afc8c65
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+  md5: 7d3fa28263bb7f8ea32db11f570a5bb6
   depends:
   - __osx >=11.0
   constrains:
-  - zlib 1.3.2 *_2
+  - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
   purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
-  size: 59000
-  timestamp: 1774073052242
+  size: 58993
+  timestamp: 1785276808631
 - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.8-h0d3cbff_0.conda
   sha256: 7e8dcf03c2ef5491405d6d86eb892d14e99902f50f4eeb250db0cbdc58dd5818
   md5: 9d5828c46147a47f828ca47a18407621
@@ -8040,15 +8015,15 @@ packages:
     - orc >=2.3.1,<2.3.2.0a0
   size: 553198
   timestamp: 1784301374348
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.3-py314h99bb933_0.conda
-  sha256: 99b33ca5a648e9cddc08cba4e425b66cb00dbba992f44f795794ed10cbb95f8f
-  md5: b8c2b629ee4792726d4c10c136457ad1
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.5-py314h99bb933_1.conda
+  sha256: 7910c507692b67567627edbed6ff0ce80bb800b704bd0b238729e4c64d9fbc4b
+  md5: 7c7abc0faf169efe0e103c62f2824857
   depends:
   - python
   - numpy >=1.26.0
   - python-dateutil >=2.8.2
-  - __osx >=11.0
   - libcxx >=19
+  - __osx >=11.0
   - numpy >=1.23,<3
   - python_abi 3.14.* *_cp314
   constrains:
@@ -8091,31 +8066,29 @@ packages:
   - xlsxwriter >=3.2.0
   - zstandard >=0.23.0
   license: BSD-3-Clause
-  license_family: BSD
   purls:
   - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
-  size: 14597208
-  timestamp: 1778602856255
-- conda: https://conda.anaconda.org/conda-forge/osx-64/polars-runtime-32-1.43.0-py310hbfc13ad_0.conda
+  size: 14639133
+  timestamp: 1785276464478
+- conda: https://conda.anaconda.org/conda-forge/osx-64/polars-runtime-32-1.43.1-py310hbfc13ad_0.conda
   noarch: python
-  sha256: 9359d485afda8e0a73c577820c5eca0bb7046b3fcd97f70129998d62d31760c0
-  md5: 53c9df9f1db4e491cf7749877f665cdd
+  sha256: f431568054048e6879eb07883c6b4f7ce738472928e0e558455e4b2c88126f15
+  md5: f9094ddf1a414754ff80ecbe88ea270d
   depends:
   - python
-  - __osx >=11.0
   - libcxx >=19
+  - __osx >=11.0
   - _python_abi3_support 1.*
   - cpython >=3.10
   constrains:
   - __osx >=10.13
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/polars-runtime-32?source=hash-mapping
   run_exports: {}
-  size: 40823985
-  timestamp: 1784642486314
+  size: 40869327
+  timestamp: 1785183536793
 - conda: https://conda.anaconda.org/conda-forge/osx-64/prek-0.4.11-h19f9e61_0.conda
   sha256: 35ec47da2aab37d7dc0d9ac5f5f6ffa2a5ab2f49b88e8a05386fc3fe60eecbd7
   md5: 383ae901bc913764fd118af7226fda82
@@ -8518,20 +8491,20 @@ packages:
   run_exports: {}
   size: 6798812
   timestamp: 1784341171527
-- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
-  sha256: 5dd728cebca2e96fa48d41661f1a35ed0ee3cb722669eee4e2d854c6745655eb
-  md5: 6276aa61ffc361cbf130d78cfb88a237
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_3.conda
+  sha256: d46ba65a5ebcb4f682f9f0f21943c427eb56e7f9d15aeab8b823294c787dbb0b
+  md5: c67ad1f1d33a7de2dd34e55c01a21eca
   depends:
   - __osx >=11.0
-  - libzlib 1.3.2 hbb4bfdb_2
+  - libzlib 1.3.2 hbb4bfdb_3
   license: Zlib
   license_family: Other
   purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
-  size: 92411
-  timestamp: 1774073075482
+  size: 93115
+  timestamp: 1785276829908
 - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
   sha256: 47101a4055a70a4876ffc87b750ab2287b67eca793f21c8224be5e1ee6394d3f
   md5: 727109b184d680772e3122f40136d5ca
@@ -8785,9 +8758,9 @@ packages:
     - aws-sdk-cpp >=1.11.833,<1.11.834.0a0
   size: 2834544
   timestamp: 1784137336612
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.36.8-py314hcec6336_0.conda
-  sha256: 51e32dd41ab7b8359677b3f7fb14ca07a1b4089723861a10f74f0b4b7c736dbe
-  md5: af806a1bb33b878a313006073b280ccd
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.36.10-py314hcec6336_0.conda
+  sha256: 2c82ec2a10724a1fdeec01c536d9745671af66944099f64c26e29152ee130ac3
+  md5: c9bd86576025547a564541721b80d6e3
   depends:
   - python
   - colorama >=0.2.5,<0.4.7
@@ -8804,12 +8777,11 @@ packages:
   - python 3.14.* *_cp314
   - python_abi 3.14.* *_cp314
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/awscli?source=hash-mapping
   run_exports: {}
-  size: 15737179
-  timestamp: 1784970317803
+  size: 15739064
+  timestamp: 1785311300156
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscrt-0.36.0-py314h6366067_0.conda
   sha256: e01aa333e1062844386c1fe17138b08ec1bc6e2df5c053d84d40e5323b415325
   md5: b8b61e824425966347aa9d5b7eefc41e
@@ -9051,6 +9023,7 @@ packages:
   - libcxx >=19
   - __osx >=11.0
   license: BSD-3-Clause
+  license_family: BSD
   purls: []
   run_exports:
     weak:
@@ -9488,46 +9461,43 @@ packages:
     - libffi >=3.5.2,<3.6.0a0
   size: 40979
   timestamp: 1769456747661
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_20.conda
-  sha256: 45fd10f5d8b4c18f95a6a515c75767095e5f602f40a03d00d9a2da00e30f82a3
-  md5: 6fdd748d713030aa15049387f44e6e3b
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.1.0-h3cf6597_1.conda
+  sha256: fdd1502babb50b802d090496586231f56236d7a6fc042a4e1ac2dee48da8366b
+  md5: 0124dc2e6f70f3e8ebea643b42b18abb
   depends:
   - _openmp_mutex
   constrains:
-  - libgcc-ng ==15.2.0=*_20
-  - libgomp 15.2.0 20
+  - libgomp 16.1.0 1
+  - libgcc-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 404529
-  timestamp: 1784926195743
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_20.conda
-  sha256: 69f19ba6cb3bd408c3c68c8988f51bc9f3623150b440ada409ac41e905237f89
-  md5: 13f8cd4261e99d055093225c2567c1d7
+  size: 364162
+  timestamp: 1785374452947
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.1.0-h07b0088_1.conda
+  sha256: d7c6dd601dbbde495ab213a76d690b2fec19455d26c595ec0257cfde3e80166b
+  md5: d6f10dbb9c5830f540904c91ea5b252a
   depends:
-  - libgfortran5 15.2.0 hdae7583_20
+  - libgfortran5 16.1.0 h32cdfcc_1
   constrains:
-  - libgfortran-ng ==15.2.0=*_20
+  - libgfortran-ng ==16.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 140115
-  timestamp: 1784926353516
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_20.conda
-  sha256: 60a329bf6979c599cc1b10ddd25ee5602b534405564d80dac0ad0a8de5cc106a
-  md5: fb8c120a070dc1ba6ae28f0e2e645962
+  size: 98528
+  timestamp: 1785374566402
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.1.0-h32cdfcc_1.conda
+  sha256: 3e8cb79a421e0c350566717febdba9079574cbbe204591b4fd4b4081ea89cb92
+  md5: c1c10ea48f95054aa9b93c2315a0a74a
   depends:
-  - libgcc >=15.2.0
+  - libgcc >=16.1.0
   constrains:
-  - libgfortran 15.2.0
+  - libgfortran 16.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   run_exports: {}
-  size: 600163
-  timestamp: 1784926204983
+  size: 556657
+  timestamp: 1785374459225
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.7.0-ha595bda_0.conda
   sha256: a5d1a020caace3dd2542edfcbec509b73d6164cf6853d0b8f78ac1cb38b57c65
   md5: 9b2bbbbe8e4c3fbfe37ab8bb57961c11
@@ -9758,21 +9728,21 @@ packages:
     - libprotobuf >=7.35.1,<7.35.2.0a0
   size: 2900719
   timestamp: 1783168180812
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-h92480b3_1.conda
-  sha256: 1dd03b21e74f41ed7af31d82f61129d94e3cce31485eb221e3acecba26ab34bf
-  md5: 9bced3ae8f4bc78a5b22f7247554c9ee
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-h7a62e17_2.conda
+  sha256: ccde1bf413f0d6f4d76dd714b018882fded6bbd1054862da10017c88f4f8a311
+  md5: 0eb67a1cb0a95320b05d8d53a24b1bff
   depends:
+  - libcxx >=19
   - __osx >=11.0
   - icu >=78.3,<79.0a0
-  - libcxx >=19
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
     - libpsl >=0.22.0,<0.23.0a0
-  size: 68846
-  timestamp: 1783937608868
+  size: 72622
+  timestamp: 1785342890032
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h5d15848_2.conda
   sha256: 06f49291605c379467987989ff08d44b470a23afeb690d7e078517871969bff7
   md5: b750c4f83563c7528634bdcfd28622ce
@@ -9898,21 +9868,21 @@ packages:
     - libxml2-16 >=2.15.3
   size: 41102
   timestamp: 1776377119495
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
-  md5: bc5a5721b6439f2f62a84f2548136082
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  md5: f39288f0ea63ae962e1a2e4f355a0d75
   depends:
   - __osx >=11.0
   constrains:
-  - zlib 1.3.2 *_2
+  - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
   purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
-  size: 47759
-  timestamp: 1774072956767
+  size: 47822
+  timestamp: 1785277049190
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
   sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
   md5: a9c118f6343fb6301b6f3b4e94c4c562
@@ -10139,25 +10109,24 @@ packages:
   run_exports: {}
   size: 14402418
   timestamp: 1784821943837
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-runtime-32-1.43.0-py310hcbcba24_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-runtime-32-1.43.1-py310hcbcba24_0.conda
   noarch: python
-  sha256: 2b07e4df01fb65a860c01f8fc1ce8ae7a58ee4d3c8747ce6bd37224dfb94159a
-  md5: 76dd30fef2fa60baf4cd8fcf7c1f9ef7
+  sha256: 9c0691cf4b52da46c866ad98d67c329f9c8345047c40b89e97681c126d116a58
+  md5: 30990212a006e4f635f52599850fc575
   depends:
   - python
-  - libcxx >=19
   - __osx >=11.0
+  - libcxx >=19
   - _python_abi3_support 1.*
   - cpython >=3.10
   constrains:
   - __osx >=11.0
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/polars-runtime-32?source=hash-mapping
+  - pkg:pypi/polars-runtime-32?source=compressed-mapping
   run_exports: {}
-  size: 36603171
-  timestamp: 1784642245117
+  size: 36668143
+  timestamp: 1785183444484
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.4.11-h6fdd925_0.conda
   sha256: b836bb7158e9560b9b6bfab221682ef32a3ab38bfc4787b525895b70e4d6649d
   md5: 812d66ff016fd35efb14e04fec41c9bc
@@ -10564,20 +10533,20 @@ packages:
   run_exports: {}
   size: 6633934
   timestamp: 1784341237426
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
-  sha256: 8dd2ac25f0ba714263aac5832d46985648f4bfb9b305b5021d702079badc08d2
-  md5: f1c0bce276210bed45a04949cfe8dc20
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_3.conda
+  sha256: ab46d85e4fcffff1b1c5cac517afa40b7ae784cf76fc9da1f55f6a6934291eb6
+  md5: 2c966485853aa27985fbec7e3fcc4e77
   depends:
   - __osx >=11.0
-  - libzlib 1.3.2 h8088a28_2
+  - libzlib 1.3.2 h8088a28_3
   license: Zlib
   license_family: Other
   purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
-  size: 81123
-  timestamp: 1774072974535
+  size: 81744
+  timestamp: 1785277062753
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
   sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
   md5: ab136e4c34e97f34fb621d2592a393d8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ platforms = ["osx-arm64", "osx-64", "linux-64", "linux-aarch64"]
 mdformat-mkdocs = ">=5.1.4"
 mdformat_simple_breaks = ">=0.1.0"
 mdformat-wikilink = ">=0.3.0"
+# Issues with python 3.14 -- try later
+# markitdown = { version = ">=0.1.7", extras = ["pdf", "docx"] }
 
 [tool.pixi.tasks.install-skills]
 cmd = "npx --yes skills experimental_install"
@@ -37,9 +39,6 @@ pixi install \
   && pixi run install-skills \
   && pixi run npm install -g \
       @anthropic-ai/claude-code \
-      @google/gemini-cli \
-      @openai/codex \
-      @earendil-works/pi-tui \
       opencode-ai
 """
 description = "Set up the dev container: install pixi environment, skills, and agent CLIs (run once after first start)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ pytest = ">=9.1.1"
 markdownlint-cli2 = ">=0.22.1"
 requests = ">=2.34.2"
 pyrefly = ">=1.1.1"
+uv = ">=0.11.33,<0.13"
 
 # These dependencies are needed inside the dev container
 gh = ">=2.95.0"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -7,12 +7,6 @@
       "skillPath": "skills/attach-db/SKILL.md",
       "computedHash": "db6a105a312536b75a58616dfd38b46909253c88fcb1ffd58bfc506ffa3065d6"
     },
-    "dignified-python": {
-      "source": "dagster-io/skills",
-      "sourceType": "github",
-      "skillPath": "skills/dignified-python/skills/dignified-python/SKILL.md",
-      "computedHash": "af77280f19bc321a9456d4695f13e6b9d9822766a0faeff2e198acea375fd5b3"
-    },
     "duckdb-docs": {
       "source": "duckdb/duckdb-skills",
       "sourceType": "github",
@@ -36,12 +30,6 @@
       "sourceType": "github",
       "skillPath": "skills/read-file/SKILL.md",
       "computedHash": "16607eb0d4dc7e2ff8d92e2bdba6bedb67aedb1189f66249a46ed672ca1782c4"
-    },
-    "skill-creator": {
-      "source": "anthropics/claude-plugins-official",
-      "sourceType": "github",
-      "skillPath": "plugins/skill-creator/skills/skill-creator/SKILL.md",
-      "computedHash": "b122f4d1e91aa1d83027e050b5b37c3156203ee85458d7b1360bc48167c9e02a"
     }
   }
 }

--- a/skills/datapackage/SKILL.md
+++ b/skills/datapackage/SKILL.md
@@ -18,7 +18,7 @@ compatibility: |
 metadata:
   - author: Catalyst Cooperative
   - email: hello@catalyst.coop
-  - last-updated: 2026-07-29
+  - last-updated: 2026-07-30
 ---
 
 # Frictionless Data Package Guide

--- a/skills/datapackage/SKILL.md
+++ b/skills/datapackage/SKILL.md
@@ -13,12 +13,12 @@ license: CC-BY-4.0
 compatibility: |
   Required CLI tools: jq >= 1.8
   Optional CLI tools: frictionless >= 5.19 (with fastparquet for Parquet support)
-  Required skills: attach-db, query (optional: install-duckdb)
+  Required skills: install-duckdb, query, attach-db
   Optional Python packages: pandas, polars, duckdb (for DataFrame work)
 metadata:
   - author: Catalyst Cooperative
   - email: hello@catalyst.coop
-  - last-updated: 2026-07-19
+  - last-updated: 2026-07-29
 ---
 
 # Frictionless Data Package Guide

--- a/skills/pudl/SKILL.md
+++ b/skills/pudl/SKILL.md
@@ -34,11 +34,11 @@ PUDL's primary outputs are Apache Parquet files, described by a Frictionless Dat
 Package descriptor. For generic descriptor-querying patterns (jq), use
 the `datapackage` skill — this skill provides PUDL-specific knowledge layered on top.
 
-Beyond the main Parquet outputs, PUDL also distributes FERC historical form databases
-(SQLite and DuckDB, covering Forms 1/2/6/60/714) and the FERC EQR (partitioned Parquet,
-separate from the main build). These have different access patterns and are not covered
-by the main Frictionless descriptor — see [Data Access](./references/data-access.md)
-for the full picture.
+Beyond the main Parquet outputs, PUDL also distributes raw per-form FERC Parquet data
+(covering Forms 1/2/6/60/714, each with its own `datapackage.json`) and the FERC EQR
+(partitioned Parquet, separate from the main build). These have different access
+patterns and are not covered by the main Frictionless descriptor — see
+[Data Access](./references/data-access.md) for the full picture.
 
 ## Workflow overview
 
@@ -50,10 +50,11 @@ the question at hand, not only when the user asks for it by name.
     - S3: `s3://pudl.catalyst.coop/nightly/pudl_parquet_datapackage.json`
     - HTTPS: `https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/pudl_parquet_datapackage.json`
 
-    FERC XBRL-derived tables have their own descriptors at the same base path:
-    `ferc1_xbrl_datapackage.json`, `ferc2_xbrl_datapackage.json`,
-    `ferc6_xbrl_datapackage.json`, `ferc60_xbrl_datapackage.json`,
-    `ferc714_xbrl_datapackage.json`
+    Raw per-form FERC data has its own `datapackage.json` in each form/era directory,
+    e.g. `s3://pudl.catalyst.coop/nightly/ferc1_xbrl/datapackage.json` and
+    `s3://pudl.catalyst.coop/nightly/ferc1_dbf/datapackage.json` — see
+    [Raw per-form Parquet directories](./references/data-access.md#raw-per-form-parquet-directories)
+    for the full list.
 
     The FERC EQR (Electric Quarterly Reports) is distributed separately due to its
     size, and only one version is publicly available at a time:

--- a/skills/pudl/SKILL.md
+++ b/skills/pudl/SKILL.md
@@ -13,15 +13,14 @@ description: >
   FERC Form 1, FERC Form 714, FERC EQR, EPA CEMS, EPA CAMD, etc.).
 license: CC-BY-4.0
 compatibility: |
-  Required skills: datapackage (which requires jq >= 1.8, attach-db, and query)
-  Required Python packages: pandas >= 2.0, s3fs (for S3 access)
-  Optional Python packages: polars >= 1.0, markitdown[pdf,docx] (to convert downloaded
-    PDF/Word blank forms and instructions to text)
-  Optional skills: dignified-python
+  Required skills: datapackage
+  Optional Python packages: polars >= 1.0 (preferred for DataFrame work), pandas >= 2.0
+    with s3fs (only needed if using pandas for S3 access), markitdown[pdf,docx] (to
+    convert downloaded PDF/Word blank forms and instructions to text)
 metadata:
   - author: Catalyst Cooperative
   - email: hello@catalyst.coop
-  - last-updated: 2026-07-19
+  - last-updated: 2026-07-29
 ---
 
 # PUDL Data Explorer Guide
@@ -134,7 +133,7 @@ the question at hand, not only when the user asks for it by name.
     distinguish between a concept-DOI and a concrete-DOI, or whenever interpreting what
     a column, code, or schedule actually means.
 - [Data Access](./references/data-access.md) — S3 paths, loading patterns
-    (pandas/DuckDB/polars/pure SQL), FERC historical database locations, and EQR access;
+    (pandas/DuckDB/polars/pure SQL), raw per-form FERC Parquet locations, and EQR access;
     read whenever generating data-loading code or explaining how to access any PUDL output
 - [PUDL Datapackage Extensions](./references/metadata-and-querying.md) — PUDL-specific
     additions to the standard datapackage schema: RST/docstring-formatted descriptions,
@@ -214,11 +213,14 @@ the question at hand, not only when the user asks for it by name.
 - **DuckDB, pandas, and polars each need explicit setup to query this bucket
     reliably** — see
     [Data Access: DuckDB and S3](./references/data-access.md#duckdb-and-s3-required-setup)
-    (`s3_url_style` plus clearing S3 credential settings; applies through `/attach-db`
-    and `/query` too) and the pandas/polars sections below it (`storage_options` for
-    anonymous access) for why each is needed.
+    (`s3_url_style` plus clearing S3 credential settings; applies through `/query` too)
+    and the pandas/polars sections below it (`storage_options` for anonymous access)
+    for why each is needed.
 
-- The Parquet path for any table is `s3://pudl.catalyst.coop/nightly/<table_name>.parquet`.
+- The Parquet path for a **core PUDL output table** is
+    `s3://pudl.catalyst.coop/nightly/<table_name>.parquet`. Raw per-form FERC tables
+    use a different path — see
+    [Raw per-form Parquet directories](./references/data-access.md#raw-per-form-parquet-directories).
 
 - **Always surface usage warnings** from the descriptor before providing loading code.
 
@@ -306,9 +308,7 @@ jq '[.[] | select(.description | test("storage"; "i"))] |
 
 ## Delegation
 
-| User intent                        | Hand off to         |
-| ---------------------------------- | ------------------- |
-| Query datapackage.json metadata    | `/datapackage`      |
-| Attach a .duckdb or .sqlite file   | `/attach-db`        |
-| Run SQL or NL queries against data | `/query`            |
-| General Python/pandas help         | `/dignified-python` |
+| User intent                        | Hand off to    |
+| ---------------------------------- | -------------- |
+| Query datapackage.json metadata    | `/datapackage` |
+| Run SQL or NL queries against data | `/query`       |

--- a/skills/pudl/SKILL.md
+++ b/skills/pudl/SKILL.md
@@ -20,7 +20,7 @@ compatibility: |
 metadata:
   - author: Catalyst Cooperative
   - email: hello@catalyst.coop
-  - last-updated: 2026-07-29
+  - last-updated: 2026-07-30
 ---
 
 # PUDL Data Explorer Guide

--- a/skills/pudl/SKILL.md
+++ b/skills/pudl/SKILL.md
@@ -15,7 +15,8 @@ license: CC-BY-4.0
 compatibility: |
   Required skills: datapackage (which requires jq >= 1.8, attach-db, and query)
   Required Python packages: pandas >= 2.0, s3fs (for S3 access)
-  Optional Python packages: polars >= 1.0
+  Optional Python packages: polars >= 1.0, markitdown[pdf,docx] (to convert downloaded
+    PDF/Word blank forms and instructions to text)
   Optional skills: dignified-python
 metadata:
   - author: Catalyst Cooperative
@@ -41,9 +42,8 @@ for the full picture.
 
 ## Workflow overview
 
-Most interactions only require steps 1–3. Steps 4 and 5 add real cost (computation,
-potentially slow S3 downloads, extra dependencies) — only proceed to them when the
-user explicitly asks to load or explore data.
+Every step below is inexpensive and should happen by default whenever it's relevant to
+the question at hand, not only when the user asks for it by name.
 
 1. **Locate the metadata** — the primary PUDL descriptor (Parquet outputs) is at:
 
@@ -90,6 +90,10 @@ user explicitly asks to load or explore data.
     the same habit applies to other sources' `core_*__codes_*` tables). Flag it if
     an answer came from recalled knowledge rather than the sweep.
 
+1. **Consult primary-source forms and instructions when metadata alone doesn't fully
+    explain something** — don't wait for the user to ask for these by name. See
+    [Data Sources: Blank forms and filer instructions](./references/data-sources.md#blank-forms-and-filer-instructions).
+
 1. **Check table tier** — see [Data Quality and Context](./references/data-quality-and-context.md).
     Prefer `out_*` tables; warn users about `_core_*` tables.
 
@@ -108,17 +112,26 @@ user explicitly asks to load or explore data.
     point the user to it. Only dive into code-level implementation after the user has
     seen that write-up or if no methodology page exists for the topic.
 
-1. *(Only if the user explicitly asks to load data)* **Load the data** — Parquet from
-    S3 or local. See [Data Access](./references/data-access.md).
+1. **Load the data, efficiently** — Loading data doesn't have to mean downloading an
+    entire table. `SELECT ... LIMIT` in DuckDB, `pl.scan_parquet()` with
+    `.select()`/`.filter()` before `.collect()` in polars, and a `columns=` argument in
+    pandas all push the selection down to the Parquet reader itself. Treat sampling and
+    down-selecting as the normal way to explore a table, not an optimization reserved
+    for when a file turns out to be huge. You should estimate a table's size before a
+    full, unfiltered load, and only load the full table if the job genuinely needs every
+    row; see [Data Access](./references/data-access.md) for the loading patterns
+    themselves.
 
 ## Reference index
 
 - [Data Sources](./references/data-sources.md) — how to query the PUDL descriptor's own
     `sources` array (31 datasets, with short codes, names, licensing, and per-source
-    documentation links); read when a user asks about a specific source dataset
-    (EIA-860, FERC Form 714, EPA CEMS, etc.) or needs documentation links, or when
+    documentation links), and where to find and read each source's blank forms and
+    filer instructions; read when a user asks about a specific source dataset
+    (EIA-860, FERC Form 714, EPA CEMS, etc.) or needs documentation links, when
     resolving a raw-archive S3 path and you need the short code and have to
-    distinguish between a concept-DOI and a concrete-DOI.
+    distinguish between a concept-DOI and a concrete-DOI, or whenever interpreting what
+    a column, code, or schedule actually means.
 - [Data Access](./references/data-access.md) — S3 paths, loading patterns
     (pandas/DuckDB/polars/pure SQL), FERC historical database locations, and EQR access;
     read whenever generating data-loading code or explaining how to access any PUDL output

--- a/skills/pudl/SKILL.md
+++ b/skills/pudl/SKILL.md
@@ -194,7 +194,15 @@ user explicitly asks to load or explore data.
     ```
 
 - The S3 bucket `s3://pudl.catalyst.coop` is **free and publicly accessible** — no
-    AWS credentials needed.
+    AWS credentials needed, and any ambient credentials (even invalid ones) should be
+    explicitly bypassed rather than assumed absent.
+
+- **DuckDB, pandas, and polars each need explicit setup to query this bucket
+    reliably** — see
+    [Data Access: DuckDB and S3](./references/data-access.md#duckdb-and-s3-required-setup)
+    (`s3_url_style` plus clearing S3 credential settings; applies through `/attach-db`
+    and `/query` too) and the pandas/polars sections below it (`storage_options` for
+    anonymous access) for why each is needed.
 
 - The Parquet path for any table is `s3://pudl.catalyst.coop/nightly/<table_name>.parquet`.
 

--- a/skills/pudl/references/data-access.md
+++ b/skills/pudl/references/data-access.md
@@ -77,6 +77,37 @@ etc.
 citation, use a fixed versioned path (e.g. `v2024.11.0`) so results are reproducible
 and the data never changes under you.
 
+### DuckDB and S3: required setup
+
+The `pudl.catalyst.coop` bucket name contains dots. DuckDB's default S3 addressing mode
+is virtual-hosted-style, which folds the bucket name into the hostname
+(`pudl.catalyst.coop.s3.us-west-2.amazonaws.com`). AWS's S3 TLS certificate only covers
+one wildcard level (`*.s3.<region>.amazonaws.com`), so that hostname doesn't match the
+certificate, and DuckDB fails with an `SSL peer certificate or SSH remote key was not OK`
+error — not a permissions or connectivity problem.
+
+This bucket is free and public and needs **no** AWS credentials — but if the user
+happens to have credentials configured (even invalid or expired ones, e.g. a stale SSO
+token), DuckDB picks up `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from the environment
+automatically and tries to sign requests with them, turning a should-just-work public
+read into a confusing `403 Forbidden` / `InvalidAccessKeyId` error. Clear them
+explicitly rather than assuming their absence.
+
+Run this once per DuckDB session before any query touching `s3://pudl.catalyst.coop/...`
+(including through `/attach-db` or `/query`):
+
+```sql
+SET s3_url_style = 'path';
+SET s3_access_key_id = '';
+SET s3_secret_access_key = '';
+```
+
+The first line switches to path-style addressing
+(`s3.us-west-2.amazonaws.com/pudl.catalyst.coop/...`), which keeps the bucket name out of
+the hostname and avoids the certificate mismatch. The next two force anonymous requests
+regardless of what's in the environment. Every DuckDB SQL example below assumes all
+three have already been set.
+
 ### FERC EQR (Electric Quarterly Reports / Form 920)
 
 The FERC EQR dataset (also known as **FERC Form 920**) is distributed separately at
@@ -105,6 +136,10 @@ Examples:
 **With DuckDB (pure SQL — no Python required):**
 
 ```sql
+SET s3_url_style = 'path';
+SET s3_access_key_id = '';
+SET s3_secret_access_key = '';
+
 -- Attach the EQR descriptor (optional, for schema inspection)
 -- Then query specific quarters directly
 SELECT * FROM read_parquet(
@@ -122,10 +157,13 @@ Parquet files from S3 without downloading them.
 ```python
 import polars as pl
 
+storage_options = {"aws_skip_signature": "true", "aws_region": "us-west-2"}
+
 # Load a single quarter
 df = (
     pl.scan_parquet(
-        "s3://pudl.catalyst.coop/ferceqr/core_ferceqr__transactions/2023q1.parquet"
+        "s3://pudl.catalyst.coop/ferceqr/core_ferceqr__transactions/2023q1.parquet",
+        storage_options=storage_options,
     )
     .select(["seller_name", "buyer_name", "transaction_quantity"])
     .collect()
@@ -133,7 +171,8 @@ df = (
 
 # Load all quarters for a year using a glob
 df = pl.scan_parquet(
-    "s3://pudl.catalyst.coop/ferceqr/core_ferceqr__transactions/2023q*.parquet"
+    "s3://pudl.catalyst.coop/ferceqr/core_ferceqr__transactions/2023q*.parquet",
+    storage_options=storage_options,
 ).collect()
 ```
 
@@ -225,9 +264,15 @@ base path. There are three known issues with these descriptors:
 Use the `/attach-db` skill to attach and query an XBRL DuckDB file
 directly from S3 without downloading. Pure SQL (no Python required):
 
+**`ATTACH` needs the `https://` URL, not `s3://`.** `read_parquet()` and `glob()`
+accept `s3://` once `s3_url_style = 'path'` is set (see above), but DuckDB's `ATTACH`
+fails with `database does not exist` for an `s3://` URI regardless of that setting —
+use the `https://s3.us-west-2.amazonaws.com/...` form instead.
+
 ```sql
 -- Attach the Form 1 XBRL database
-ATTACH 's3://pudl.catalyst.coop/nightly/ferc1_xbrl.duckdb' AS ferc1 (READ_ONLY);
+ATTACH 'https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/ferc1_xbrl.duckdb'
+    AS ferc1 (READ_ONLY);
 
 -- List available tables
 SHOW ALL TABLES;
@@ -244,7 +289,8 @@ import duckdb
 
 con = duckdb.connect()
 con.execute(
-    "ATTACH 's3://pudl.catalyst.coop/nightly/ferc1_xbrl.duckdb' AS ferc1 (READ_ONLY)"
+    "ATTACH 'https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/ferc1_xbrl.duckdb'"
+    " AS ferc1 (READ_ONLY)"
 )
 df = con.execute(
     "SELECT * FROM ferc1.steam_electric_generating_plant_statistics_large_plants_402_duration LIMIT 100"
@@ -262,13 +308,22 @@ column name doesn't guarantee a matching unit, and mismatched-scale units (e.g. 
 
 ### With pandas
 
+**Pass `storage_options={"anon": True}`.** Without it, pandas/s3fs falls back to
+anonymous access only when it finds no credentials at all — but if the user has any
+AWS credentials configured, even invalid or expired ones, s3fs tries to sign requests
+with them first and fails with a `403`/`ACCESS_DENIED` error instead of falling back.
+Passing `anon=True` explicitly skips the credential lookup entirely, so this works the
+same way regardless of what's in the user's environment.
+
 ```python
 import pandas as pd
 
 table = "out_eia923__generation"
 
-# From S3 (no credentials needed)
-df = pd.read_parquet(f"s3://pudl.catalyst.coop/nightly/{table}.parquet")
+# From S3 (no credentials needed or used)
+df = pd.read_parquet(
+    f"s3://pudl.catalyst.coop/nightly/{table}.parquet", storage_options={"anon": True}
+)
 
 # From local file
 df = pd.read_parquet(f"/path/to/pudl_parquet/{table}.parquet")
@@ -277,6 +332,7 @@ df = pd.read_parquet(f"/path/to/pudl_parquet/{table}.parquet")
 df = pd.read_parquet(
     f"s3://pudl.catalyst.coop/nightly/{table}.parquet",
     columns=["plant_id_eia", "report_date", "net_generation_mwh"],
+    storage_options={"anon": True},
 )
 ```
 
@@ -288,6 +344,10 @@ df = pd.read_parquet(
 Pure SQL (no Python required) — use `/query` to run these:
 
 ```sql
+SET s3_url_style = 'path';
+SET s3_access_key_id = '';
+SET s3_secret_access_key = '';
+
 SELECT plant_id_eia, report_date, net_generation_mwh
 FROM read_parquet('s3://pudl.catalyst.coop/nightly/out_eia923__generation.parquet')
 WHERE report_date >= '2020-01-01'
@@ -299,7 +359,11 @@ Or from Python:
 ```python
 import duckdb
 
-result = duckdb.sql("""
+con = duckdb.connect()
+con.execute("SET s3_url_style = 'path'")
+con.execute("SET s3_access_key_id = ''")
+con.execute("SET s3_secret_access_key = ''")
+result = con.execute("""
     SELECT plant_id_eia, report_date, net_generation_mwh
     FROM read_parquet('s3://pudl.catalyst.coop/nightly/out_eia923__generation.parquet')
     WHERE report_date >= '2020-01-01'
@@ -312,12 +376,20 @@ hourly tables (e.g., `out_ferc714__respondents_hourly`).
 
 ### With polars (memory-efficient alternative to pandas)
 
+**Pass `storage_options` explicitly.** Unlike pandas/s3fs, polars does not fall back to
+anonymous access on its own — with no AWS credentials or region configured (the common
+case, since this bucket needs neither), it hangs trying an EC2 instance-metadata lookup
+and then fails because it can't determine the bucket's region. Skip both problems with:
+
 ```python
 import polars as pl
 
 table = "out_eia923__generation"
 
-lf = pl.scan_parquet(f"s3://pudl.catalyst.coop/nightly/{table}.parquet")
+lf = pl.scan_parquet(
+    f"s3://pudl.catalyst.coop/nightly/{table}.parquet",
+    storage_options={"aws_skip_signature": "true", "aws_region": "us-west-2"},
+)
 df = lf.select(["plant_id_eia", "report_date", "net_generation_mwh"]).collect()
 ```
 
@@ -329,8 +401,12 @@ down column selection and row filters to the Parquet reader.
 ## Listing all available tables
 
 ```sql
+SET s3_url_style = 'path';
+SET s3_access_key_id = '';
+SET s3_secret_access_key = '';
+
 -- Pure DuckDB SQL: list all Parquet tables in the nightly build
-SELECT filename
+SELECT file
 FROM glob('s3://pudl.catalyst.coop/nightly/*.parquet');
 ```
 

--- a/skills/pudl/references/data-access.md
+++ b/skills/pudl/references/data-access.md
@@ -301,6 +301,16 @@ df = con.execute(
 
 ## Loading PUDL Parquet tables
 
+**Sample or aggregate by default rather than pulling a full table.** Some PUDL tables
+are multiple gigabytes; loading one in full to answer a question that a `LIMIT`, a row
+filter, a column selection, or an aggregate query would have answered just as well
+wastes time and memory for no benefit. DuckDB's `LIMIT`/`WHERE`, polars'
+`scan_parquet().select().filter().collect()` lazy pipeline, and pandas'
+`columns=`/`filters=` arguments all push the selection down to the Parquet reader
+itself, so only the requested data is ever transferred. Reach for whichever narrows the
+read before reaching for a full load. You should estimate a table's size before a full,
+unfiltered load, and only load the full table if the job genuinely needs every row.
+
 **Summing or joining quantity columns?** Check each field's `unit` first — a matching
 column name doesn't guarantee a matching unit, and mismatched-scale units (e.g. `Mcf` vs
 `MMcf`) combine silently into a wrong-but-plausible number. See
@@ -316,24 +326,30 @@ Passing `anon=True` explicitly skips the credential lookup entirely, so this wor
 same way regardless of what's in the user's environment.
 
 ```python
+import datetime
+
 import pandas as pd
 
 table = "out_eia923__generation"
 
-# From S3 (no credentials needed or used)
+# Default: narrow to the columns (and, via `filters=`, the rows) you actually need --
+# much faster for large tables, since the selection is pushed down to the reader.
+# `filters=` compares against the column's actual type -- a date column needs a
+# `datetime.date`, not a string, or pyarrow raises ArrowNotImplementedError.
+df = pd.read_parquet(
+    f"s3://pudl.catalyst.coop/nightly/{table}.parquet",
+    columns=["plant_id_eia", "report_date", "net_generation_mwh"],
+    filters=[("report_date", ">=", datetime.date(2020, 1, 1))],
+    storage_options={"anon": True},
+)
+
+# Only when the task genuinely needs every column: drop `columns=`/`filters=`
 df = pd.read_parquet(
     f"s3://pudl.catalyst.coop/nightly/{table}.parquet", storage_options={"anon": True}
 )
 
-# From local file
+# From local file (same columns=/filters= arguments apply)
 df = pd.read_parquet(f"/path/to/pudl_parquet/{table}.parquet")
-
-# Load only specific columns (much faster for large tables)
-df = pd.read_parquet(
-    f"s3://pudl.catalyst.coop/nightly/{table}.parquet",
-    columns=["plant_id_eia", "report_date", "net_generation_mwh"],
-    storage_options={"anon": True},
-)
 ```
 
 `s3fs` must be installed for S3 access. Install with `uv add s3fs` (preferred) or
@@ -390,11 +406,17 @@ lf = pl.scan_parquet(
     f"s3://pudl.catalyst.coop/nightly/{table}.parquet",
     storage_options={"aws_skip_signature": "true", "aws_region": "us-west-2"},
 )
-df = lf.select(["plant_id_eia", "report_date", "net_generation_mwh"]).collect()
+# Default: chain .select()/.filter() before .collect() so column and row pruning
+# happen at the Parquet reader, not after the whole table is already in memory.
+df = (
+    lf.select(["plant_id_eia", "report_date", "net_generation_mwh"])
+    .filter(pl.col("report_date") >= pl.date(2020, 1, 1))
+    .collect()
+)
 ```
 
-Polars lazy evaluation (`scan_parquet`) is preferred for tables > 500 MB — it pushes
-down column selection and row filters to the Parquet reader.
+Polars lazy evaluation (`scan_parquet`) is preferred since it pushes down column
+selection and row filters to the Parquet reader.
 
 ---
 

--- a/skills/pudl/references/data-access.md
+++ b/skills/pudl/references/data-access.md
@@ -87,7 +87,7 @@ read into a confusing `403 Forbidden` / `InvalidAccessKeyId` error. Clear them
 explicitly rather than assuming their absence.
 
 Run this once per DuckDB session before any query touching `s3://pudl.catalyst.coop/...`
-(including through `/attach-db` or `/query`):
+(including through `/query`):
 
 ```sql
 SET s3_url_style = 'path';
@@ -259,9 +259,14 @@ SELECT file
 FROM glob('s3://pudl.catalyst.coop/nightly/ferc1_xbrl/*.parquet');
 ```
 
-Or query the descriptor with jq (see the `datapackage` skill for full querying patterns):
+Or query the descriptor with jq (see the `datapackage` skill for full querying patterns).
+The remote filename inside every form/era directory is always `datapackage.json` — download
+it and give the local copy a disambiguated name so you can tell descriptors apart once
+you've fetched more than one:
 
 ```bash
+curl -o ferc1_xbrl_datapackage.json \
+    https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/ferc1_xbrl/datapackage.json
 jq -r '.resources[].name' ferc1_xbrl_datapackage.json
 ```
 

--- a/skills/pudl/references/data-access.md
+++ b/skills/pudl/references/data-access.md
@@ -45,17 +45,12 @@ every time you are about to generate data-loading code:
     line to their shell startup file (e.g. `~/.zshrc`, `~/.bashrc`, or
     `~/.profile`) if you have permission to edit environment files.
 
-1. **FERC raw databases** — the FERC DuckDB and SQLite files can also be downloaded
-    for local use. Only suggest this if the user has already been querying them
-    remotely in the current session — these are much messier than the processed PUDL
-    Parquet outputs, so don't proactively recommend them.
-
 ---
 
 ## Data locations
 
-All PUDL outputs — Parquet files, FERC SQLite/DuckDB databases, and descriptors — are
-free and publicly accessible on AWS S3. No AWS credentials or account needed.
+All PUDL outputs — Parquet files and datapackage.json descriptors — are free and
+publicly accessible on AWS S3. No AWS credentials or account needed.
 
 ### Core PUDL outputs
 
@@ -66,12 +61,10 @@ free and publicly accessible on AWS S3. No AWS credentials or account needed.
 | Local download (`$PUDL_DATA`)               | `$PUDL_DATA/<table_name>.parquet`                         |
 | Local PUDL pipeline output (`$PUDL_OUTPUT`) | `$PUDL_OUTPUT/parquet/<table_name>.parquet`               |
 
-Datapackage JSON descriptors at the same base path: `pudl_parquet_datapackage.json`,
-`ferc1_xbrl_datapackage.json`, `ferc2_xbrl_datapackage.json`,
-`ferc6_xbrl_datapackage.json`, `ferc60_xbrl_datapackage.json`,
-`ferc714_xbrl_datapackage.json`. If using local PUDL pipeline output, these databases
-will be in the directory above the Parquet files: `$PUDL_OUTPUT/ferc1_xbrl_datapackage.json`,
-etc.
+The core PUDL Parquet outputs share a single descriptor at the same base path:
+`pudl_parquet_datapackage.json`. The raw per-form FERC data described in
+[FERC historical form data](#ferc-historical-form-data) below has its own
+`datapackage.json` per form/era directory.
 
 **Use S3 nightly** for most exploratory work. For production pipelines or academic
 citation, use a fixed versioned path (e.g. `v2024.11.0`) so results are reproducible
@@ -183,11 +176,12 @@ Descriptor:
 
 ---
 
-## FERC historical form databases
+## FERC historical form data
 
 FERC Forms 1, 2, 6, 60, and 714 span two distinct filing eras with different source
-formats. PUDL converts these into databases published alongside the core Parquet
-outputs at the same S3 base path.
+formats. PUDL converts each form/era combination into a set of raw Parquet files
+published alongside the core PUDL outputs at the same S3 base path — one Parquet file
+per table, plus a `datapackage.json` descriptor, inside a per-form/era directory.
 
 ### Reporting epochs
 
@@ -199,102 +193,76 @@ outputs at the same S3 base path.
 | Form 60 (Centralized Service Companies)                         | DBF              | 2006–2020    | 2021–present |
 | Form 714 (Electricity Balancing Authorities and Planning Areas) | CSV (DBF export) | 2006-2020    | 2021–present |
 
+**Form 714 has no DBF-derived Parquet data.** The legacy CSV export was never
+converted; only the XBRL-derived raw data (2021–present) and the integrated PUDL
+tables (2006–present) are available for Form 714.
+
 ### PUDL integration status
 
 Always check whether a PUDL integrated table exists before falling back to raw
-databases. Integrated tables are cleaned, entity-resolved, and span all years with a
-uniform schema.
+per-form data. Integrated tables are cleaned, entity-resolved, and span all years with
+a uniform schema.
 
 - **FERC Form 1**: Only some schedules have been integrated. See
     [FERC Form 1 Schedules](./ferc1-schedules.md) for the per-schedule breakdown.
-    For unintegrated Form 1 schedules, use the raw DBF or XBRL databases below.
-    Only provide raw Form 1 data if a user **explicitly** requests it.
+    For unintegrated Form 1 schedules, use the raw DBF- or XBRL-derived Parquet files
+    below. Only provide raw Form 1 data if a user **explicitly** requests it.
 - **FERC Forms 2, 6, and 60**: None of this data has been integrated into PUDL.
-    It is only available through the raw databases.
+    It is only available through the raw per-form Parquet files.
 - **FERC Form 714**: Only the integrated PUDL tables span pre-2021 years.
     The legacy CSV files were not structured for general machine-readable extraction.
     Integrated Form 714 tables cover all electronic reporting years (2006–present).
 
-### DBF-derived databases (pre-2021, Forms 1/2/6/60)
+### Raw per-form Parquet directories
 
-PUDL consolidates all DBF years for each form into a single SQLite database:
-
-| Form    | S3 path                                                 |
-| ------- | ------------------------------------------------------- |
-| Form 1  | `s3://pudl.catalyst.coop/nightly/ferc1_dbf.sqlite.zip`  |
-| Form 2  | `s3://pudl.catalyst.coop/nightly/ferc2_dbf.sqlite.zip`  |
-| Form 6  | `s3://pudl.catalyst.coop/nightly/ferc6_dbf.sqlite.zip`  |
-| Form 60 | `s3://pudl.catalyst.coop/nightly/ferc60_dbf.sqlite.zip` |
-
-**No datapackage descriptors exist** for these databases — the original DBF files are
-almost entirely undocumented. For Form 1, the [FERC Form 1 Schedules](./ferc1-schedules.md)
-reference provides a hand-compiled schedule-to-table mapping. No equivalent mapping
-exists for Forms 2, 6, or 60.
-
-### XBRL-derived databases (2021–present, all forms)
-
-PUDL converts XBRL filings into both SQLite and DuckDB:
-
-| Form     | DuckDB (preferred)                                    | SQLite (zipped, must download)                            |
-| -------- | ----------------------------------------------------- | --------------------------------------------------------- |
-| Form 1   | `s3://pudl.catalyst.coop/nightly/ferc1_xbrl.duckdb`   | `s3://pudl.catalyst.coop/nightly/ferc1_xbrl.sqlite.zip`   |
-| Form 2   | `s3://pudl.catalyst.coop/nightly/ferc2_xbrl.duckdb`   | `s3://pudl.catalyst.coop/nightly/ferc2_xbrl.sqlite.zip`   |
-| Form 6   | `s3://pudl.catalyst.coop/nightly/ferc6_xbrl.duckdb`   | `s3://pudl.catalyst.coop/nightly/ferc6_xbrl.sqlite.zip`   |
-| Form 60  | `s3://pudl.catalyst.coop/nightly/ferc60_xbrl.duckdb`  | `s3://pudl.catalyst.coop/nightly/ferc60_xbrl.sqlite.zip`  |
-| Form 714 | `s3://pudl.catalyst.coop/nightly/ferc714_xbrl.duckdb` | `s3://pudl.catalyst.coop/nightly/ferc714_xbrl.sqlite.zip` |
-
-**Prefer DuckDB**: DuckDB files can be queried remotely (see below) without
-downloading. SQLite files are published as `.zip` archives, must be downloaded and
-unzipped before use, and cannot be read remotely; some exceed 1 GB uncompressed.
-
-Datapackage descriptors with table and column metadata exist for the XBRL databases:
-`ferc1_xbrl_datapackage.json`, `ferc2_xbrl_datapackage.json`, etc., at the same S3
-base path. There are three known issues with these descriptors:
-
-1. **Absolute path bug**: the `path` field for each resource contains an absolute path
-    from the build machine (e.g. `/home/user/pudl-work/ferc1_xbrl.sqlite`). Use only
-    the final filename component to construct the actual S3 path.
-1. **Points at SQLite, not DuckDB**: the `path` field always refers to the `.sqlite`
-    file. Replace `.sqlite` with `.duckdb` to get the DuckDB path.
-1. **Table descriptions are not useful**: they contain raw XBRL entity names rather
-    than human-readable descriptions. Rely on the table name and column names instead.
-
-### Querying XBRL databases with DuckDB
-
-Use the `/attach-db` skill to attach and query an XBRL DuckDB file
-directly from S3 without downloading. Pure SQL (no Python required):
-
-**`ATTACH` needs the `https://` URL, not `s3://`.** `read_parquet()` and `glob()`
-accept `s3://` once `s3_url_style = 'path'` is set (see above), but DuckDB's `ATTACH`
-fails with `database does not exist` for an `s3://` URI regardless of that setting —
-use the `https://s3.us-west-2.amazonaws.com/...` form instead.
-
-```sql
--- Attach the Form 1 XBRL database
-ATTACH 'https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/ferc1_xbrl.duckdb'
-    AS ferc1 (READ_ONLY);
-
--- List available tables
-SHOW ALL TABLES;
-
--- Query a specific schedule table
-SELECT * FROM ferc1.steam_electric_generating_plant_statistics_large_plants_402_duration
-LIMIT 100;
+```text
+s3://pudl.catalyst.coop/nightly/<form>_<era>/datapackage.json
+s3://pudl.catalyst.coop/nightly/<form>_<era>/<table_name>.parquet
 ```
 
-Or from Python if needed:
+| Form     | DBF-derived (legacy)                          | XBRL-derived (2021–present)                     |
+| -------- | --------------------------------------------- | ----------------------------------------------- |
+| Form 1   | `s3://pudl.catalyst.coop/nightly/ferc1_dbf/`  | `s3://pudl.catalyst.coop/nightly/ferc1_xbrl/`   |
+| Form 2   | `s3://pudl.catalyst.coop/nightly/ferc2_dbf/`  | `s3://pudl.catalyst.coop/nightly/ferc2_xbrl/`   |
+| Form 6   | `s3://pudl.catalyst.coop/nightly/ferc6_dbf/`  | `s3://pudl.catalyst.coop/nightly/ferc6_xbrl/`   |
+| Form 60  | `s3://pudl.catalyst.coop/nightly/ferc60_dbf/` | `s3://pudl.catalyst.coop/nightly/ferc60_xbrl/`  |
+| Form 714 | *(none — see above)*                          | `s3://pudl.catalyst.coop/nightly/ferc714_xbrl/` |
 
-```python
-import duckdb
+For example, the Form 1 XBRL table `identification_001_duration` lives at
+`s3://pudl.catalyst.coop/nightly/ferc1_xbrl/identification_001_duration.parquet`, and
+its descriptor is at `s3://pudl.catalyst.coop/nightly/ferc1_xbrl/datapackage.json`.
 
-con = duckdb.connect()
-con.execute(
-    "ATTACH 'https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/ferc1_xbrl.duckdb'"
-    " AS ferc1 (READ_ONLY)"
-)
-df = con.execute(
-    "SELECT * FROM ferc1.steam_electric_generating_plant_statistics_large_plants_402_duration LIMIT 100"
-).df()
+These are read the same way as any other PUDL Parquet table — see
+[Loading PUDL Parquet tables](#loading-pudl-parquet-tables) below, substituting the
+form/era directory for `nightly/`. Use the `datapackage` skill against each
+directory's `datapackage.json` to discover table and column names before querying.
+
+DBF-derived table names are the original (often cryptic) FERC identifiers, e.g.
+`f1_adit_amrt_prop`. Hand-compiled schedule-to-table mappings are available for Forms
+1 (Electricity) and 2 (Gas Pipelines):
+
+- [FERC Form 1 Schedules and Tables](./ferc1-schedules.md)
+- [FERC Form 2 Schedules and Tables](./ferc2-schedules.md)
+
+Equivalent mappings do not yet exist for Forms 6 or 60.
+
+### Listing tables in a raw per-form directory
+
+Using DuckDB:
+
+```sql
+SET s3_url_style = 'path';
+SET s3_access_key_id = '';
+SET s3_secret_access_key = '';
+
+SELECT file
+FROM glob('s3://pudl.catalyst.coop/nightly/ferc1_xbrl/*.parquet');
+```
+
+Or query the descriptor with jq (see the `datapackage` skill for full querying patterns):
+
+```bash
+jq -r '.resources[].name' ferc1_xbrl_datapackage.json
 ```
 
 ---

--- a/skills/pudl/references/data-sources.md
+++ b/skills/pudl/references/data-sources.md
@@ -114,12 +114,82 @@ if you share the link with the user, give them the plain `.html` URL from the fi
 See [PUDL Datapackage Extensions: Per-resource provenance](./metadata-and-querying.md#per-resource-provenance-sources)
 for exactly how that append works.
 
+**Exception: fetch the raw `.html` page (not `.md`) for the "Download additional
+documentation" links** — see
+[Blank forms and filer instructions](#blank-forms-and-filer-instructions) below for why.
+
 ```bash
 # Fetch a source's docs page (markdown version)
 jq -r '.sources[] | select(.name == "eia923") | .documentation + ".md"' "$PKG" | xargs curl -s
 ```
 
 Or use the `WebFetch` tool if available in your environment.
+
+## Blank forms and filer instructions
+
+Table and column descriptions in the descriptor summarize what data *contains*, but
+they rarely explain what a filer was actually asked to report. For that, go to the
+source: the blank form and filer instructions a respondent used to fill it out. These
+define a code's exact scope, what a schedule line item is asking for, or how a term was
+defined in a given filing year — context that's often impossible to infer from a column
+name or description alone, and that changes as forms are revised over the years.
+
+**Check for these whenever you're about to explain what something in the data means,**
+not only when the user names the form and asks for it directly — most users won't know
+these documents exist. If the source has a `documentation` page, look for a "Download
+additional documentation" section on it before falling back to a description-only
+answer.
+
+### Finding them
+
+Fetch the **raw `.html`** docs page for this section, not the `.md` mirror. The `.md`
+mirror does list the same files, but as relative links that don't resolve to a working
+URL; the `.html` page's links resolve to `https://docs.catalyst.coop/pudl/en/nightly/_downloads/<hash>/<filename>`,
+which does work. This is the one place on the docs site where the `.md`-first rule
+above should not be followed.
+
+```bash
+# Find the "Download additional documentation" section for a source
+curl -s "$(jq -r '.sources[] | select(.name == "ferc1") | .documentation' "$PKG")" |
+    grep -A50 'id="download-additional-documentation"'
+```
+
+Not every source has this section — most FERC forms and some EIA forms do; many
+sources don't, and some (e.g. `ferc2` at the time of writing) don't have a
+`documentation` page at all yet. If a source has neither, say so rather than guessing
+at or constructing a URL; point the user to the source agency's own page instead (the
+`path` field on that source's `sources` record).
+
+Python's `urllib` returns `403 Forbidden` fetching from `docs.catalyst.coop` with its
+default `User-Agent` string — override it with any other value. `curl` and `requests`
+both work fine with their own defaults.
+
+### Choosing an edition
+
+Multiple editions accumulate over the years as a form is revised. **Prefer the newest
+edition** — it's the most likely to describe current reporting practice — with one
+twist: recent FERC forms are published as plain `.html`, while older editions (and most
+EIA instructions) are PDFs. When a newer edition is easier to read (HTML) than an older
+one (PDF), that's an extra reason to prefer it, not just its recency.
+
+### Reading them
+
+HTML editions are plain text — fetch and read them directly, same as any other web page.
+PDFs and Word documents (`.docx`, occasionally used for cover memos or errata) need
+converting to text first.
+Download the file, then convert it with [markitdown](https://github.com/microsoft/markitdown)
+(`uv pip install "markitdown[pdf,docx]"` if not already available — the base package
+alone doesn't include PDF or docx support; add other extras the same way for other
+formats you run into):
+
+```bash
+curl -s -o ferc1_blank_2019-12-31.pdf \
+    "https://docs.catalyst.coop/pudl/en/nightly/_downloads/fd9ba713087c5c0be586ac51ba237731/ferc1_blank_2019-12-31.pdf"
+markitdown ferc1_blank_2019-12-31.pdf > ferc1_blank_2019-12-31.md
+```
+
+These forms often run 50-100+ pages; skim the converted markdown or search it for the
+schedule, line item, or term you need rather than reading it front to back.
 
 ### Zenodo and DOI conventions
 

--- a/skills/pudl/references/data-sources.md
+++ b/skills/pudl/references/data-sources.md
@@ -69,7 +69,9 @@ The **`name`** field is the short code used in:
 
 - Cached raw-archive paths: `s3://pudl.catalyst.coop/zenodo/<name>/<concrete-doi>/`
 - Table name prefixes (second component): e.g. `out_eia923__generation`
-- FERC XBRL descriptor filenames: e.g. `ferc1_xbrl_datapackage.json`
+- Raw per-form FERC directory names: e.g. `nightly/ferc1_xbrl/` (each such directory
+    holds a `datapackage.json` plus one Parquet file per table — see
+    [Data Access: Raw per-form Parquet directories](./data-access.md#raw-per-form-parquet-directories))
 
 ---
 

--- a/skills/pudl/references/ferc1-schedules.md
+++ b/skills/pudl/references/ferc1-schedules.md
@@ -90,9 +90,12 @@ Raw tables come in two formats depending on the filing year:
 - **DBF (1994–2020):** tables in `ferc1_dbf.sqlite`. Table names start with `f1_`.
 
 Source (schedule titles): FERC Form 1 blank form (2025-07-31 edition),
-"LIST OF SCHEDULES (Electric Utility)". The blank form HTML and older PDF versions can
-be downloaded from links in the PUDL docs:
-[FERC Form 1 additional documentation](https://docs.catalyst.coop/pudl/en/nightly/data_sources/ferc1.html#download-additional-documentation)
+"LIST OF SCHEDULES (Electric Utility)". The blank form and filer instructions are also
+the best source for what a specific schedule or line item actually asks respondents to
+report — see
+[Data Sources: Blank forms and filer instructions](./data-sources.md#blank-forms-and-filer-instructions)
+for how to find and read the current and historical editions
+([download links](https://docs.catalyst.coop/pudl/en/nightly/data_sources/ferc1.html#download-additional-documentation)).
 
 Source (DBF table names): Hand-compiled mapping published as the
 [FERC Form 1 DBF data dictionary](https://docs.catalyst.coop/pudl/en/nightly/data_dictionaries/ferc1_db.html).

--- a/skills/pudl/references/ferc1-schedules.md
+++ b/skills/pudl/references/ferc1-schedules.md
@@ -82,12 +82,16 @@ only when:
 
 Raw tables come in two formats depending on the filing year:
 
-- **XBRL (2021–present):** tables in `ferc1_xbrl.duckdb` / `ferc1_xbrl.sqlite`. Table
-    names embed the schedule/page number just before the `_duration` or `_instant` suffix.
-    Duration tables record changes over a period; instant tables record point-in-time
-    balances. Many schedules have multiple sub-tables (e.g. one per section or account
-    type).
-- **DBF (1994–2020):** tables in `ferc1_dbf.sqlite`. Table names start with `f1_`.
+- **XBRL (2021–present):** Parquet tables in
+    `s3://pudl.catalyst.coop/nightly/ferc1_xbrl/`. Table names embed the schedule/page
+    number just before the `_duration` or `_instant` suffix. Duration tables record
+    changes over a period; instant tables record point-in-time balances. Many
+    schedules have multiple sub-tables (e.g. one per section or account type).
+- **DBF (1994–2020):** Parquet tables in
+    `s3://pudl.catalyst.coop/nightly/ferc1_dbf/`. Table names start with `f1_`.
+
+See [Raw per-form Parquet directories](./data-access.md#raw-per-form-parquet-directories)
+for how to load these.
 
 Source (schedule titles): FERC Form 1 blank form (2025-07-31 edition),
 "LIST OF SCHEDULES (Electric Utility)". The blank form and filer instructions are also

--- a/skills/pudl/references/ferc2-schedules.md
+++ b/skills/pudl/references/ferc2-schedules.md
@@ -62,8 +62,13 @@ Many schedules are split across multiple sub-tables in the XBRL database, one pe
 section, account type, or monthly period.
 
 Source (schedule titles and descriptions): FERC Form 2 blank form (2025-07-31 edition).
-The blank form HTML can be found at
-`docs/data_sources/ferc2/ferc2_blank_2025-07-31.html` in the PUDL source repository.
+`ferc2` doesn't have a PUDL docs page yet (its `documentation` field is `null` — see
+[Data Sources](./data-sources.md#the-sources-schema)), so its blank form and filer
+instructions aren't linked from `docs.catalyst.coop` the way FERC Form 1's are. Get them
+from the source agency's own page instead — the `path` field on the `ferc2` `sources`
+record. See
+[Data Sources: Blank forms and filer instructions](./data-sources.md#blank-forms-and-filer-instructions)
+for the general pattern for sources that do have a docs page.
 
 ---
 

--- a/skills/pudl/references/ferc2-schedules.md
+++ b/skills/pudl/references/ferc2-schedules.md
@@ -47,11 +47,16 @@ in `SKILL.md` for that pattern.
 
 ## About FERC Form 2 data
 
-None of FERC Form 2 has yet been integrated into the main PUDL data pipeline. The raw
-XBRL-derived data (2021–present) is available in `ferc2_xbrl.duckdb` and
-`ferc2_xbrl.sqlite`. There is no equivalent DBF-era database for Form 2 yet.
+None of FERC Form 2 has yet been integrated into the main PUDL data pipeline. Raw
+Parquet tables are available for both eras:
 
-Raw tables come in two formats within the XBRL database:
+- **XBRL (2021–present):** `s3://pudl.catalyst.coop/nightly/ferc2_xbrl/`
+- **DBF (1996–2020):** `s3://pudl.catalyst.coop/nightly/ferc2_dbf/`
+
+See [Raw per-form Parquet directories](./data-access.md#raw-per-form-parquet-directories)
+for how to load these.
+
+Raw tables come in two formats within the XBRL-derived data:
 
 - **Duration tables** (`_duration` suffix): record values that apply over a time period
     (e.g. income, expenses, changes in plant balance).

--- a/skills/pudl/references/ferc2-schedules.md
+++ b/skills/pudl/references/ferc2-schedules.md
@@ -19,8 +19,8 @@ Companies; there is no separate accounts reference file for gas companies in thi
 ## Querying the machine-readable index
 
 Use [`ferc2_schedules.json`](../assets/ferc2_schedules.json) for all programmatic
-lookups. `xbrl_tables` and `ferc_accounts` are typed arrays; `schedule` is the page key.
-`pudl_tables` and `dbf_tables` are present but currently empty (Form 2 is not yet
+lookups. `xbrl_tables`, `dbf_tables`, and `ferc_accounts` are typed arrays; `schedule`
+is the page key. `pudl_tables` is present but currently empty (Form 2 is not yet
 integrated into PUDL).
 
 ### jq examples
@@ -63,8 +63,8 @@ Raw tables come in two formats within the XBRL-derived data:
 - **Instant tables** (`_instant` suffix): record point-in-time balances (e.g. balance
     sheet accounts, end-of-year plant totals).
 
-Many schedules are split across multiple sub-tables in the XBRL database, one per
-section, account type, or monthly period.
+Many schedules are split across multiple sub-tables in the XBRL-derived Parquet data,
+one per section, account type, or monthly period.
 
 Source (schedule titles and descriptions): FERC Form 2 blank form (2025-07-31 edition).
 `ferc2` doesn't have a PUDL docs page yet (its `documentation` field is `null` — see

--- a/skills/pudl/references/metadata-and-querying.md
+++ b/skills/pudl/references/metadata-and-querying.md
@@ -181,8 +181,6 @@ right_total = gas_a + gas_b.to("Mcf")  # 2_700 Mcf
 
 ---
 
----
-
 ## Joining PUDL tables: use declared foreign keys, and PUDL's ID crosswalks
 
 **Before joining two PUDL resources, check `schema.foreignKeys` on each — don't join

--- a/skills/pudl/scripts/fetch_descriptor.py
+++ b/skills/pudl/scripts/fetch_descriptor.py
@@ -28,16 +28,23 @@ from pathlib import Path
 _NIGHTLY = "https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly"
 _FERCEQR = "https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/ferceqr"
 
-# Maps each descriptor filename to its S3 base URL.
-# Most descriptors live under /nightly; FERC EQR has its own path.
+# Maps each local cache filename to its full descriptor URL on S3. The core PUDL
+# descriptor and FERC EQR keep their filename in the URL, but each raw per-form FERC
+# directory (e.g. nightly/ferc1_xbrl/) publishes a same-named datapackage.json, so the
+# local cache filename below is a disambiguated <form>_<era>_datapackage.json name and
+# the URL points at the actual remote path.
 _DESCRIPTOR_URLS: dict[str, str] = {
-    "pudl_parquet_datapackage.json": _NIGHTLY,
-    "ferc1_xbrl_datapackage.json": _NIGHTLY,
-    "ferc2_xbrl_datapackage.json": _NIGHTLY,
-    "ferc6_xbrl_datapackage.json": _NIGHTLY,
-    "ferc60_xbrl_datapackage.json": _NIGHTLY,
-    "ferc714_xbrl_datapackage.json": _NIGHTLY,
-    "ferceqr_parquet_datapackage.json": _FERCEQR,
+    "pudl_parquet_datapackage.json": f"{_NIGHTLY}/pudl_parquet_datapackage.json",
+    "ferc1_dbf_datapackage.json": f"{_NIGHTLY}/ferc1_dbf/datapackage.json",
+    "ferc1_xbrl_datapackage.json": f"{_NIGHTLY}/ferc1_xbrl/datapackage.json",
+    "ferc2_dbf_datapackage.json": f"{_NIGHTLY}/ferc2_dbf/datapackage.json",
+    "ferc2_xbrl_datapackage.json": f"{_NIGHTLY}/ferc2_xbrl/datapackage.json",
+    "ferc6_dbf_datapackage.json": f"{_NIGHTLY}/ferc6_dbf/datapackage.json",
+    "ferc6_xbrl_datapackage.json": f"{_NIGHTLY}/ferc6_xbrl/datapackage.json",
+    "ferc60_dbf_datapackage.json": f"{_NIGHTLY}/ferc60_dbf/datapackage.json",
+    "ferc60_xbrl_datapackage.json": f"{_NIGHTLY}/ferc60_xbrl/datapackage.json",
+    "ferc714_xbrl_datapackage.json": f"{_NIGHTLY}/ferc714_xbrl/datapackage.json",
+    "ferceqr_parquet_datapackage.json": f"{_FERCEQR}/ferceqr_parquet_datapackage.json",
 }
 
 DESCRIPTORS: list[str] = list(_DESCRIPTOR_URLS)
@@ -74,8 +81,7 @@ def fetch_one(filename: str, force: bool = False) -> tuple[str, int, str, bool]:
             digest = hashlib.sha256(data).hexdigest()[:12]
             return filename, len(data), digest, True
 
-    base = _DESCRIPTOR_URLS.get(filename, _NIGHTLY)
-    url = f"{base}/{filename}"
+    url = _DESCRIPTOR_URLS.get(filename, f"{_NIGHTLY}/{filename}")
 
     last_error: Exception | None = None
     for attempt in range(1, MAX_ATTEMPTS + 1):


### PR DESCRIPTION
# Overview

We had a little show-and-tell this morning and I made notes of things that needed improvements, and rolled them into this PR.

- Update PUDL skill to rely entirely on Parquet outputs, since we have them for all of our data now.
- Fix some TLS certificate issue that was making it hard to attach to DuckDB
- Update examples and tests to assume no AWS credentials or even bad AWS credentials -- you don't need any for the PUDL data, so don't let them get in the way.
- Give better, more permissive instructions to agents for looking up original source material for context.
- Point agents at `markitdown` so they can convert PDF, DOCX, XLSX, PPT, HTML, etc files directly to markdown.
- Give more permissive instructions to agents allowing them to download data early on, but provide guidance to make sure it is efficient (lazy loading, sample / limited, filter, column-wise selection, etc.)
- Add tests for all of the functionality that we touched which wasn't yet being tested.
- Update docs and `last-updated` timestamps.

# To-do list

- [ ] Review the PR yourself and call out any questions or issues you have

